### PR TITLE
Fix compile error with AngelScript string operator==.

### DIFF
--- a/scriptsystem/scriptstdstring.cpp
+++ b/scriptsystem/scriptstdstring.cpp
@@ -506,6 +506,13 @@ static char *StringCharAt(unsigned int i, string &str)
 
 
 // AngelScript signature:
+// bool string::opEquals(const string &in) const
+static bool StringEquals(const string &a, const string &b)
+{
+	return a == b;
+}
+
+// AngelScript signature:
 // int string::opCmp(const string &in) const
 static int StringCmp(const string &a, const string &b)
 {
@@ -574,7 +581,7 @@ void RegisterStdString_Native(asIScriptEngine *engine)
 	r = engine->RegisterObjectMethod("string", "string &opAssign(const string &in)", asMETHODPR(string, operator =, (const string&), string&), asCALL_THISCALL); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string &opAddAssign(const string &in)", asMETHODPR(string, operator+=, (const string&), string&), asCALL_THISCALL); assert( r >= 0 );
 
-	r = engine->RegisterObjectMethod("string", "bool opEquals(const string &in) const", asFUNCTIONPR(operator ==, (const string &, const string &), bool), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
+	r = engine->RegisterObjectMethod("string", "bool opEquals(const string &in) const", asFUNCTION(StringEquals), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "int opCmp(const string &in) const", asFUNCTION(StringCmp), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
 	r = engine->RegisterObjectMethod("string", "string opAdd(const string &in) const", asFUNCTIONPR(operator +, (const string &, const string &), string), asCALL_CDECL_OBJFIRST); assert( r >= 0 );
 


### PR DESCRIPTION
This had me stumped for a while. I guess it's just not able to find
```C++
static bool operator==(const std::string&, const std::string&)
```
in the global scope? Maybe it conflicts with `std::basic_string` template parameters? Not sure.

I based my changes off of `StringCmp`, and it compiles just fine now with `gcc -c scriptstdstring.cpp` in Cygwin.