### PR TITLE
Added FindENet.cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,12 +323,12 @@ include_directories(${XLEngine_SOURCE_DIR}/thirdparty/AngelCode/sdk/angelscript/
 
 # Include/library directories.
 set(xlengine_include_dirs
-    ${ENET_INCLUDE_DIR}
+    ${ENET_INCLUDE_DIRS}
     ${GLEW_INCLUDE_DIR}
     ${IL_INCLUDE_DIR})
 set(xlengine_libraries
     angelscript
-    ${ENET_LIBRARY}
+    ${ENET_LIBRARIES}
     GLEW::GLEW
     ${IL_LIBRARIES}
     ${OPENGL_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,10 @@ set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 
 include(CheckLibraryExists)
 
-find_package(OpenGL REQUIRED)
-find_package(GLEW REQUIRED)
 find_package(DevIL REQUIRED)
+find_package(ENet REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(OpenGL REQUIRED)
 find_package(Threads REQUIRED)
 if(NOT WIN32)
     find_package(SDL2 REQUIRED)
@@ -321,17 +322,16 @@ source_group("world" FILES ${world_sources})
 include_directories(${XLEngine_SOURCE_DIR}/thirdparty/AngelCode/sdk/angelscript/include)
 
 # Include/library directories.
-# - TODO: find ENet. Currently has to be found and set manually.
-# - TODO: Use enet64.lib on 64-bit.
 set(xlengine_include_dirs
+    ${ENET_INCLUDE_DIR}
     ${GLEW_INCLUDE_DIR}
     ${IL_INCLUDE_DIR})
 set(xlengine_libraries
-    GLEW::GLEW
-    ${OPENGL_LIBRARIES}
-    ${IL_LIBRARIES}
-    enet
     angelscript
+    ${ENET_LIBRARY}
+    GLEW::GLEW
+    ${IL_LIBRARIES}
+    ${OPENGL_LIBRARIES}
     Threads::Threads)
 
 # Platform-specific includes/libraries.

--- a/cmake/FindENet.cmake
+++ b/cmake/FindENet.cmake
@@ -1,0 +1,27 @@
+# - Find ENet
+# Find the ENet libraries
+#
+#  This module defines the following variables:
+#     ENET_FOUND        - True if ENET_INCLUDE_DIR & ENET_LIBRARY are found
+#     ENET_INCLUDE_DIRS - where to find enet.h, etc.
+#     ENET_LIBRARIES    - the ENet library
+#
+#============================================================================
+
+find_path(ENET_INCLUDE_DIR NAMES enet/enet.h
+        DOC "The ENet include directory")
+
+find_library(ENET_LIBRARY NAMES enet enet64
+        DOC "The ENet library")
+
+# Handle the QUIETLY and REQUIRED arguments and set ENET_FOUND to TRUE if
+# all listed variables are TRUE.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ENET REQUIRED_VARS ENET_LIBRARY ENET_INCLUDE_DIR)
+
+if(ENET_FOUND)
+    set(ENET_LIBRARIES ${ENET_LIBRARY})
+    set(ENET_INCLUDE_DIRS ${ENET_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(ENET_INCLUDE_DIR ENET_LIBRARY)


### PR DESCRIPTION
This should let 32-bit Visual Studio builds work now (more or less anyway -- it crashed after trying to load MAPS.BSA, probably a problem on my side).

I noticed that the pre-built `enet.lib` and `enet64.lib` files that come with ENet are not compatible with newer Visual Studio versions due to a SAFESEH (safe exception handlers) error, so VS devs will probably still need to build ENet themselves, or they can disable the /SAFESEH option in `Linker > Advanced > Image Has Safe Exception Handlers` (not sure how safe that is, though).