### PR TITLE
Changed NULL to nullptr

### DIFF
--- a/BloodXL/BloodXL_Game.cpp
+++ b/BloodXL/BloodXL_Game.cpp
@@ -5,7 +5,7 @@
 #include "../ui/Console.h"
 
 //Game instance used for console commands.
-BloodXL_Game *BloodXL_Game::s_pGame_Console=NULL;
+BloodXL_Game *BloodXL_Game::s_pGame_Console=nullptr;
 
 BloodXL_Game::BloodXL_Game(const XLEngine_Plugin_API *API)
 {
@@ -103,7 +103,7 @@ BloodXL_Game::~BloodXL_Game(void)
     if ( m_Player )
     {
         xlDelete m_Player;
-        m_Player = NULL;
+        m_Player = nullptr;
     }
 }
 

--- a/BloodXL/BloodXL_main.cpp
+++ b/BloodXL/BloodXL_main.cpp
@@ -2,7 +2,7 @@
 #include "BloodXL_Game.h"
 
 //this is static for now.
-BloodXL_Game *m_pGame=NULL;
+BloodXL_Game *m_pGame=nullptr;
 
 //Interface between Game classes and C library interface.
 void BloodXL_Update(int32_t stage, float dt, XLEngine_Plugin_API *API, void *pUserData)
@@ -45,7 +45,7 @@ void BloodXL_DestroyGame()
     {
         xlDelete m_pGame;
     }
-    m_pGame = NULL;
+    m_pGame = nullptr;
 }
 
 //Dynamic library C interface.
@@ -58,8 +58,8 @@ extern "C" PLUGIN_API int32_t ExitFunc()
 
 extern "C" PLUGIN_API XL_ExitFunc XL_initPlugin(const XLEngine_Plugin_API *API)
 {
-    API->SetGameUpdateCallback( BloodXL_Update, NULL );
-    API->SetGameRenderCallback( BloodXL_Render, NULL );
+    API->SetGameUpdateCallback( BloodXL_Update, nullptr );
+    API->SetGameRenderCallback( BloodXL_Render, nullptr );
     API->AddKeyDownCallback( BloodXL_KeyDownCallback, Input::KDCb_FLAGS_NONE );
     
     BloodXL_CreateGame( API );

--- a/CommonTypes.h
+++ b/CommonTypes.h
@@ -60,9 +60,9 @@ typedef int32_t XL_BOOL;
 #define XL_INVALID_TEXTURE 0xffffffff
 typedef uint32_t TextureHandle;
 
-//Make sure that the point is non-null before delete. Set to NULL.
-#define SafeDeleteArr(p) if (p) { xlDelete [] (p); (p) = NULL; }
+//Make sure that the point is non-null before delete. Set to null.
+#define SafeDeleteArr(p) if (p) { xlDelete [] (p); (p) = nullptr; }
 //p must be non-null before deletion. Test and set to null.
-#define SafeDeleteArr_Test(p) { assert(p); if (p) { xlDelete [] (p); (p) = NULL; } }
+#define SafeDeleteArr_Test(p) { assert(p); if (p) { xlDelete [] (p); (p) = nullptr; } }
 
 #endif  //COMMON_TYPES

--- a/DaggerXL/DaggerXL_Game.cpp
+++ b/DaggerXL/DaggerXL_Game.cpp
@@ -8,10 +8,10 @@
 #include "../ui/Console.h"
 
 //Game instance used for console commands.
-DaggerXL_Game *DaggerXL_Game::s_pGame_Console=NULL;
+DaggerXL_Game *DaggerXL_Game::s_pGame_Console=nullptr;
 #define NPC_COUNT 32
 
-static DaggerXL_Game *s_pGamePtr = NULL;
+static DaggerXL_Game *s_pGamePtr = nullptr;
 
 DaggerXL_Game::DaggerXL_Game(const XLEngine_Plugin_API *API)
 {
@@ -53,7 +53,7 @@ DaggerXL_Game::DaggerXL_Game(const XLEngine_Plugin_API *API)
     m_NPC_Logic = xlNew Logic_NPC(API);
     m_Player = xlNew DaggerXL_Player(API);
 
-    m_pAPI->World_SetUpdateCallback( DaggerXL_Game::WorldUpdate, NULL );
+    m_pAPI->World_SetUpdateCallback( DaggerXL_Game::WorldUpdate, nullptr );
 
     s_pGamePtr = this;
 }
@@ -63,22 +63,22 @@ DaggerXL_Game::~DaggerXL_Game(void)
     if ( m_Player )
     {
         xlDelete m_Player;
-        m_Player = NULL;
+        m_Player = nullptr;
     }
     if ( m_DoorLogic )
     {
         xlDelete m_DoorLogic;
-        m_DoorLogic = NULL;
+        m_DoorLogic = nullptr;
     }
     if ( m_ObjActionLogic )
     {
         xlDelete m_ObjActionLogic;
-        m_ObjActionLogic = NULL;
+        m_ObjActionLogic = nullptr;
     }
     if ( m_NPC_Logic )
     {
         xlDelete m_NPC_Logic;
-        m_NPC_Logic = NULL;
+        m_NPC_Logic = nullptr;
     }
     for (uint32_t n=0; n<NPC_COUNT; n++)
     {

--- a/DaggerXL/DaggerXL_main.cpp
+++ b/DaggerXL/DaggerXL_main.cpp
@@ -2,7 +2,7 @@
 #include "DaggerXL_Game.h"
 
 //this is static for now.
-DaggerXL_Game *m_pGame=NULL;
+DaggerXL_Game *m_pGame=nullptr;
 
 void DaggerXL_Update(int32_t stage, float dt, XLEngine_Plugin_API *API, void *pUserData)
 {
@@ -44,7 +44,7 @@ void DaggerXL_DestroyGame()
     {
         xlDelete m_pGame;
     }
-    m_pGame = NULL;
+    m_pGame = nullptr;
 }
 
 extern "C" PLUGIN_API int32_t ExitFunc()
@@ -56,8 +56,8 @@ extern "C" PLUGIN_API int32_t ExitFunc()
 
 extern "C" PLUGIN_API XL_ExitFunc XL_initPlugin(const XLEngine_Plugin_API *API)
 {
-    API->SetGameUpdateCallback( DaggerXL_Update, NULL );
-    API->SetGameRenderCallback( DaggerXL_Render, NULL );
+    API->SetGameUpdateCallback( DaggerXL_Update, nullptr );
+    API->SetGameRenderCallback( DaggerXL_Render, nullptr );
     API->AddKeyDownCallback( DaggerXL_KeyDownCallback, Input::KDCb_FLAGS_NOREPEAT );
     
     DaggerXL_CreateGame( API );

--- a/DarkXL/CutscenePlayer.cpp
+++ b/DarkXL/CutscenePlayer.cpp
@@ -74,7 +74,7 @@ void CutscenePlayer::LoadCutsceneData()
 
         //free pData
         xlDelete [] pData;
-        pData = NULL;
+        pData = nullptr;
     }
 }
 

--- a/DarkXL/DarkXL_Game.cpp
+++ b/DarkXL/DarkXL_Game.cpp
@@ -3,7 +3,7 @@
 #include "../ui/Console.h"
 
 //Game instance used for console commands.
-DarkXL_Game *DarkXL_Game::s_pGame_Console=NULL;
+DarkXL_Game *DarkXL_Game::s_pGame_Console=nullptr;
 
 DarkXL_Game::DarkXL_Game(const XLEngine_Plugin_API *API)
 {

--- a/DarkXL/DarkXL_main.cpp
+++ b/DarkXL/DarkXL_main.cpp
@@ -2,7 +2,7 @@
 #include "DarkXL_Game.h"
 
 //this is static for now.
-DarkXL_Game *m_pGame=NULL;
+DarkXL_Game *m_pGame=nullptr;
 
 //Interface between Game classes and C library interface.
 void DarkXL_Update(int32_t stage, float dt, XLEngine_Plugin_API *API, void *pUserData)
@@ -45,7 +45,7 @@ void DarkXL_DestroyGame()
     {
         xlDelete m_pGame;
     }
-    m_pGame = NULL;
+    m_pGame = nullptr;
 }
 
 //Dynamic library C interface.
@@ -58,8 +58,8 @@ extern "C" PLUGIN_API int32_t ExitFunc()
 
 extern "C" PLUGIN_API XL_ExitFunc XL_initPlugin(const XLEngine_Plugin_API *API)
 {
-    API->SetGameUpdateCallback( DarkXL_Update, NULL );
-    API->SetGameRenderCallback( DarkXL_Render, NULL );
+    API->SetGameUpdateCallback( DarkXL_Update, nullptr );
+    API->SetGameRenderCallback( DarkXL_Render, nullptr );
     API->AddKeyDownCallback( DarkXL_KeyDownCallback, Input::KDCb_FLAGS_NONE );
     
     DarkXL_CreateGame( API );

--- a/Engine.cpp
+++ b/Engine.cpp
@@ -47,13 +47,13 @@ const float m_fFixedLoopsPerSec = 60.0f;
 const float m_fFixedLoopTime = (1.0f/m_fFixedLoopsPerSec);
 
 //Plugin API.
-Engine *m_pEngineForAPI=NULL;
-XAPI_Game_Update m_pGameUpdate=NULL;
-XAPI_Game_Render m_pGameRender=NULL;
-XAPI_World_Update m_pWorldUpdate=NULL;
-void *m_pGameUpdate_UD=NULL;
-void *m_pGameRender_UD=NULL;
-void *m_pWorldUpdate_UD=NULL;
+Engine *m_pEngineForAPI=nullptr;
+XAPI_Game_Update m_pGameUpdate=nullptr;
+XAPI_Game_Render m_pGameRender=nullptr;
+XAPI_World_Update m_pWorldUpdate=nullptr;
+void *m_pGameUpdate_UD=nullptr;
+void *m_pGameRender_UD=nullptr;
+void *m_pWorldUpdate_UD=nullptr;
 char m_szGameName[64]="";
 int m_anVersion[2]={0,0};
 
@@ -68,7 +68,7 @@ struct DisplayMessage
 DisplayMessage m_aMessages[MAX_MESSAGE_COUNT];
 int32_t m_nMessageCnt=0;
 
-IDriver3D *g_pDriver3D = NULL;
+IDriver3D *g_pDriver3D = nullptr;
 
 #define _MAX_TIMEOUT 5.0f
 #define _FRAME_COUNT_BEFORE_EXIT 60
@@ -80,14 +80,14 @@ bool Engine::m_bContinueLoop=true;
 
 Engine::Engine()
 {
-    m_pDriver3D = NULL;
-    m_pCamera = NULL;
-    m_pPluginAPI = NULL;
+    m_pDriver3D = nullptr;
+    m_pCamera = nullptr;
+    m_pPluginAPI = nullptr;
     m_fTotalTime = 0.0f;
-    m_pSystemFont16 = NULL;
-    m_pSystemFont24 = NULL;
-    m_pSystemFont32 = NULL;
-    m_pWorld = NULL;
+    m_pSystemFont16 = nullptr;
+    m_pSystemFont24 = nullptr;
+    m_pSystemFont32 = nullptr;
+    m_pWorld = nullptr;
     m_FPS = 60.0f;
 }
 
@@ -120,7 +120,7 @@ bool Engine::Init(void **winParam, int32_t paramCnt, int32_t w, int32_t h)
             ((Driver3D_Soft *)m_pDriver3D)->SetBitDepth(8);
         }
 
-        if ( m_pDriver3D == NULL )
+        if ( m_pDriver3D == nullptr )
             return false;
 
         g_pDriver3D = m_pDriver3D;
@@ -128,7 +128,7 @@ bool Engine::Init(void **winParam, int32_t paramCnt, int32_t w, int32_t h)
 
     //Create the default camera.
     m_pCamera = xlNew Camera();
-    if ( m_pCamera == NULL )
+    if ( m_pCamera == nullptr )
         return false;
 
     //pick the correct platform based on OS.
@@ -340,12 +340,12 @@ void Engine::Destroy()
     if ( m_pCamera )
     {
         xlDelete m_pCamera;
-        m_pCamera = NULL;
+        m_pCamera = nullptr;
     }
     if ( m_pPluginAPI )
     {
         xlFree( m_pPluginAPI );
-        m_pPluginAPI = NULL;
+        m_pPluginAPI = nullptr;
     }
     MovieManager::Destroy();
     Input::Destroy();
@@ -367,7 +367,7 @@ void Engine::Destroy()
     if ( m_pDriver3D )
     {
         xlDelete m_pDriver3D;
-        m_pDriver3D = NULL;
+        m_pDriver3D = nullptr;
     }
 
     //ScratchPad
@@ -376,7 +376,7 @@ void Engine::Destroy()
     if ( m_pWorld )
     {
         xlDelete m_pWorld;
-        m_pWorld = NULL;
+        m_pWorld = nullptr;
     }
 }
 
@@ -387,7 +387,7 @@ void Engine::InitGame(const char *pszGameLib)
 
 XLFont *Engine::GetSystemFont(int32_t size)
 {
-    XLFont *pFont = NULL;
+    XLFont *pFont = nullptr;
 
     if ( size == 16 )
         pFont = m_pSystemFont16;
@@ -432,7 +432,7 @@ void Engine::AddDisplayMessage(const char *pszMsg, Vector4 *color, float fShowTi
 float Engine::GetCurrentBrightness()
 {
     Object *player = m_pWorld->GetPlayer();
-    if ( player == NULL )
+    if ( player == nullptr )
         return 1.0f;
 
     return player->GetBrightness();

--- a/OutlawsXL/OutlawsXL_Game.cpp
+++ b/OutlawsXL/OutlawsXL_Game.cpp
@@ -5,7 +5,7 @@
 #include "../ui/Console.h"
 
 //Game instance used for console commands.
-OutlawsXL_Game *OutlawsXL_Game::s_pGame_Console=NULL;
+OutlawsXL_Game *OutlawsXL_Game::s_pGame_Console=nullptr;
 
 OutlawsXL_Game::OutlawsXL_Game(const XLEngine_Plugin_API *API)
 {
@@ -38,7 +38,7 @@ OutlawsXL_Game::~OutlawsXL_Game(void)
     if ( m_Player )
     {
         xlDelete m_Player;
-        m_Player = NULL;
+        m_Player = nullptr;
     }
 }
 

--- a/OutlawsXL/OutlawsXL_main.cpp
+++ b/OutlawsXL/OutlawsXL_main.cpp
@@ -2,7 +2,7 @@
 #include "OutlawsXL_Game.h"
 
 //this is static for now.
-OutlawsXL_Game *m_pGame=NULL;
+OutlawsXL_Game *m_pGame=nullptr;
 
 //Interface between Game classes and C library interface.
 void OutlawsXL_Update(int32_t stage, float dt, XLEngine_Plugin_API *API, void *pUserData)
@@ -45,7 +45,7 @@ void OutlawsXL_DestroyGame()
     {
         xlDelete m_pGame;
     }
-    m_pGame = NULL;
+    m_pGame = nullptr;
 }
 
 //Dynamic library C interface.
@@ -58,8 +58,8 @@ extern "C" PLUGIN_API int32_t ExitFunc()
 
 extern "C" PLUGIN_API XL_ExitFunc XL_initPlugin(const XLEngine_Plugin_API *API)
 {
-    API->SetGameUpdateCallback( OutlawsXL_Update, NULL );
-    API->SetGameRenderCallback( OutlawsXL_Render, NULL );
+    API->SetGameUpdateCallback( OutlawsXL_Update, nullptr );
+    API->SetGameRenderCallback( OutlawsXL_Render, nullptr );
     API->AddKeyDownCallback( OutlawsXL_KeyDownCallback, Input::KDCb_FLAGS_NONE );
 
     OutlawsXL_CreateGame( API );

--- a/fileformats/ART_Reader.cpp
+++ b/fileformats/ART_Reader.cpp
@@ -13,8 +13,8 @@ char _szFileName[32];
 ART_Reader::ART_Reader() : Archive()
 {
     m_CurFile = -1;
-    m_pFile = NULL;
-    m_pTilesList = NULL;
+    m_pFile = nullptr;
+    m_pTilesList = nullptr;
     m_uFileCount = 0;
 }
 
@@ -129,7 +129,7 @@ void ART_Reader::CloseFile()
     if ( m_pFile )
     {
         fclose(m_pFile);
-        m_pFile = NULL;
+        m_pFile = nullptr;
     }
     m_CurFile = -1;
 }

--- a/fileformats/ArchiveManager.cpp
+++ b/fileformats/ArchiveManager.cpp
@@ -26,8 +26,8 @@ FILE *ArchiveManager::s_pCurrentSysFile;
 
 void ArchiveManager::Init()
 {
-    m_pCurArchive=NULL;
-    s_pCurrentSysFile=NULL;
+    m_pCurArchive=nullptr;
+    s_pCurrentSysFile=nullptr;
     TextureLoader::Init();
 }
 
@@ -60,7 +60,7 @@ Archive *ArchiveManager::OpenArchive(uint32_t uArchiveType, const char *pszArchi
     }
 
     //now we have to allocate and setup the archive...
-    Archive *pArchive=NULL;
+    Archive *pArchive=nullptr;
     switch (uArchiveType)
     {
         case ARCHIVETYPE_GOB:
@@ -173,7 +173,7 @@ void *ArchiveManager::GameFile_GetFileInfo()
     {
         return m_pCurArchive->ReadFileInfo();
     }
-    return NULL;
+    return nullptr;
 }
 
 void ArchiveManager::GameFile_Close()
@@ -182,7 +182,7 @@ void ArchiveManager::GameFile_Close()
     {
         m_pCurArchive->CloseFile();
     }
-    m_pCurArchive=NULL;
+    m_pCurArchive=nullptr;
 }
 
 int32_t ArchiveManager::File_Open(const char *pszFileName)
@@ -222,7 +222,7 @@ void ArchiveManager::File_Read(void *pData, uint32_t uStart, uint32_t uLength)
 
 void *ArchiveManager::File_GetFileInfo()
 {
-    return NULL;
+    return nullptr;
 }
 
 void ArchiveManager::File_Close()
@@ -231,5 +231,5 @@ void ArchiveManager::File_Close()
     {
         fclose(s_pCurrentSysFile);
     }
-    s_pCurrentSysFile = NULL;
+    s_pCurrentSysFile = nullptr;
 }

--- a/fileformats/BSA_Reader.cpp
+++ b/fileformats/BSA_Reader.cpp
@@ -8,9 +8,9 @@
 BSA_Reader::BSA_Reader() : Archive()
 {
     m_CurFile = -1;
-    m_pFile = NULL;
-    m_pFileListName = NULL;
-    m_pFileListNum  = NULL;
+    m_pFile = nullptr;
+    m_pFileListName = nullptr;
+    m_pFileListNum  = nullptr;
 }
 
 bool BSA_Reader::Open(const char *pszName)
@@ -54,12 +54,12 @@ void BSA_Reader::Close()
     if ( m_pFileListName )
     {
         delete [] m_pFileListName;
-        m_pFileListName = NULL;
+        m_pFileListName = nullptr;
     }
     if ( m_pFileListNum )
     {
         delete [] m_pFileListNum;
-        m_pFileListNum = NULL;
+        m_pFileListNum = nullptr;
     }
     m_bOpen = false;
 }
@@ -69,7 +69,7 @@ bool BSA_Reader::OpenFile(const char *pszFile)
     if ( m_Header.DirectoryType != DT_NameRecord )
         return false;
 
-    assert(m_pFile == NULL);
+    assert(m_pFile == nullptr);
     m_pFile = fopen(m_szFileName, "rb");
     m_CurFile = -1;
     
@@ -88,7 +88,7 @@ bool BSA_Reader::OpenFile(const char *pszFile)
         if ( m_CurFile == -1 )
         {
             fclose(m_pFile);
-            m_pFile = NULL;
+            m_pFile = nullptr;
             XL_Console::PrintF("^1Error: Failed to load %s from \"%s\"", pszFile, m_szFileName);
         }
     }
@@ -101,7 +101,7 @@ bool BSA_Reader::OpenFile(const uint32_t uID)
     if ( m_Header.DirectoryType != DT_NumberRecord )
         return false;
 
-    assert(m_pFile == NULL);
+    assert(m_pFile == nullptr);
     m_pFile = fopen(m_szFileName, "rb");
     assert(m_pFile);
     m_CurFile = -1;
@@ -121,7 +121,7 @@ bool BSA_Reader::OpenFile(const uint32_t uID)
         if ( m_CurFile == -1 )
         {
             fclose(m_pFile);
-            m_pFile = NULL;
+            m_pFile = nullptr;
 
             XL_Console::PrintF("^1Error: Failed to load %u from \"%s\"", uID, m_szFileName);
         }
@@ -186,7 +186,7 @@ void BSA_Reader::CloseFile()
     if ( m_pFile )
     {
         fclose(m_pFile);
-        m_pFile = NULL;
+        m_pFile = nullptr;
     }
     m_CurFile = -1;
 }

--- a/fileformats/CellLoader_BloodMap.cpp
+++ b/fileformats/CellLoader_BloodMap.cpp
@@ -24,9 +24,9 @@ const float m_fWorldToTexel_Z = 8.0f;
 
 CellLoader_BloodMap::CellLoader_BloodMap() : CellLoader()
 {
-    m_pBloodSectors = NULL;
-    m_pBloodWalls = NULL;
-    m_pBloodSprites = NULL;
+    m_pBloodSectors = nullptr;
+    m_pBloodWalls = nullptr;
+    m_pBloodSprites = nullptr;
 }
 
 CellLoader_BloodMap::~CellLoader_BloodMap()
@@ -36,7 +36,7 @@ CellLoader_BloodMap::~CellLoader_BloodMap()
 void CellLoader_BloodMap::DecryptBuffer(uint8_t *pBuffer, const uint32_t uDataSize, uint8_t uDecryptKey)
 {
     // Variables
-    assert(pBuffer != NULL);
+    assert(pBuffer != nullptr);
 
     // If the map isn't encrypted
     if (!m_bIsEncrypted)
@@ -388,7 +388,7 @@ TextureHandle CellLoader_BloodMap::AddBloodTile(int32_t picnum, uint32_t uPalIdx
 
 WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY )
 {
-    WorldCell *pCell = NULL;
+    WorldCell *pCell = nullptr;
     ObjectManager::FreeAllObjects();
     if ( uLen )
     {
@@ -397,20 +397,20 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
         int32_t offset = FindFirstSector((char *)pData, index);
         if ( offset < 0 )
         {
-            return NULL;
+            return nullptr;
         }
         index = offset;
         if ( ExtractSectors((char *)pData, index) == false )
         {
-            return NULL;
+            return nullptr;
         }
         if ( ExtractWalls((char *)pData, index) == false )
         {
-            return NULL;
+            return nullptr;
         }
         if ( ExtractSprites((char *)pData, index) == false )
         {
-            return NULL;
+            return nullptr;
         }
 
         pCell = xlNew WorldCell();
@@ -510,7 +510,7 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
 
             /****************** Setup LevelFunc ****************/
             //is this a sliding door sector?
-            pSector->m_pFunc = NULL;
+            pSector->m_pFunc = nullptr;
             int16_t rxID = -1;
             int16_t waitTime = 0;
             bool bLink = false;
@@ -518,7 +518,7 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
             if ( m_pBloodSectors[i].lotag == 600 )  //Z-Motion
             {
                 //z-motion - like an elevator.
-                pSector->m_pFunc = NULL;
+                pSector->m_pFunc = nullptr;
 
                 //floor or ceiling, add for both?
                 if ( m_pBloodSectors[i].floorStates[0] != m_pBloodSectors[i].floorStates[1] )
@@ -783,7 +783,7 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
                 }
             }
 
-            if ( /*pSector->m_pFunc == NULL && */(m_pBloodSectors[i].motionFX_flags&MOTIONFX_PANALWAYS) )
+            if ( /*pSector->m_pFunc == nullptr && */(m_pBloodSectors[i].motionFX_flags&MOTIONFX_PANALWAYS) )
             {
                 pSector->m_pFunc = LevelFuncMgr::CreateLevelFunc("MotionFX", i, -1);
                 pSector->m_pFunc->SetSpeed( (float)m_pBloodSectors[i].motionFX_speed/(64.0f*30.0f) );
@@ -798,7 +798,7 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
 
                 pSector->m_pFunc->SetDirection(dir);
             }
-            else if ( pSector->m_pFunc == NULL && m_pBloodSectors[i].lightFX_wave > 0 )
+            else if ( pSector->m_pFunc == nullptr && m_pBloodSectors[i].lightFX_wave > 0 )
             {
                 pSector->m_pFunc = LevelFuncMgr::CreateLevelFunc("LightFX", i, -1);
                 pSector->m_pFunc->SetSpeed( 0.33f/60.0f );
@@ -814,7 +814,7 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
             {
                 int32_t ww = m_pBloodSectors[i].wallptr + w;
 
-                pSector->m_Walls[w].m_pFunc = NULL;
+                pSector->m_Walls[w].m_pFunc = nullptr;
                 if ( (rxID > -1 && m_pBloodWalls[ww].txID == rxID) || bTriggerAllWalls )
                 {
                     pSector->m_Walls[w].m_pFunc = LevelFuncMgr::CreateLevelFunc("TriggerToggle", i, w);
@@ -1116,7 +1116,7 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
                                     }
                                 }
                             }
-                            if ( nClosest > -1 && pSector->m_Walls[nClosest].m_pFunc == NULL )
+                            if ( nClosest > -1 && pSector->m_Walls[nClosest].m_pFunc == nullptr )
                             {
                                 pSector->m_Walls[nClosest].m_pFunc = LevelFuncMgr::CreateLevelFunc("TriggerToggle", pSector->m_uID, nClosest);
                                 pSector->m_Walls[nClosest].m_pFunc->AddClient( pSector->m_pFunc );
@@ -1358,17 +1358,17 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
         if ( m_pBloodSectors )
         {
             xlDelete [] m_pBloodSectors;
-            m_pBloodSectors = NULL;
+            m_pBloodSectors = nullptr;
         }
         if ( m_pBloodWalls )
         {
             xlDelete [] m_pBloodWalls;
-            m_pBloodWalls = NULL;
+            m_pBloodWalls = nullptr;
         }
         if ( m_pBloodSprites )
         {
             xlDelete [] m_pBloodSprites;
-            m_pBloodSprites = NULL;
+            m_pBloodSprites = nullptr;
         }
     }
 

--- a/fileformats/CellLoader_Daggerfall.cpp
+++ b/fileformats/CellLoader_Daggerfall.cpp
@@ -210,7 +210,7 @@ WorldCell *CellLoader_Daggerfall::LoadFromLocation( IDriver3D *pDriver, World *p
 {
     Location_Daggerfall *pLocation = (Location_Daggerfall *)pLocPtr;
 
-    WorldCell *pCell = NULL;
+    WorldCell *pCell = nullptr;
     int32_t worldX = (int32_t)pLocation->m_x;
     int32_t worldY = (int32_t)pLocation->m_y;
 
@@ -222,7 +222,7 @@ WorldCell *CellLoader_Daggerfall::LoadFromLocation( IDriver3D *pDriver, World *p
     }
     else
     {
-        return NULL;
+        return nullptr;
     }
 
     WorldMap::SetWorldCell(worldX>>3, worldY>>3, pCell);
@@ -257,7 +257,7 @@ WorldCell *CellLoader_Daggerfall::LoadFromLocation( IDriver3D *pDriver, World *p
         int32_t wy_map = worldY_Orig>>3;
         float fTileHeight = Math::Max( pTerrain->GetHeight_MapScale(wx_map, wy_map), 16.0f );
         int32_t worldY = worldY_Orig;
-        if ( pLocation->m_pTexData == NULL )
+        if ( pLocation->m_pTexData == nullptr )
         {
              pLocation->m_pTexData = new uint8_t[256*pLocation->m_BlockWidth*pLocation->m_BlockHeight];
         }
@@ -292,7 +292,7 @@ WorldCell *CellLoader_Daggerfall::LoadFromLocation( IDriver3D *pDriver, World *p
     {
         int dungeonType = 1;
 
-        Vector3 *pvStartLoc = NULL;
+        Vector3 *pvStartLoc = nullptr;
         int startBlock = pLocation->m_startDungeonBlock;
         if ( pLocation->m_dungeonBlockCnt == 1 )
         {
@@ -356,7 +356,7 @@ WorldCell *CellLoader_Daggerfall::Load( IDriver3D *pDriver, World *pWorld, uint8
     Location_Daggerfall *pLocation = WorldMap::GetLocation(sFile.c_str());
     //Don't reload a location already in memory.
     if ( pLocation && pLocation->m_bLoaded )
-        return NULL;
+        return nullptr;
 
     return LoadFromLocation( pDriver, pWorld, pLocation );
 }
@@ -443,7 +443,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
     {
         index = outside_index;
         int32_t extIndex = (int32_t)pSector->m_Objects.size()-1;
-        Object *pExtMesh=NULL;
+        Object *pExtMesh=nullptr;
         //exterior
         BlockHeader *pBlockHeader = (BlockHeader *)&pData[index]; index += 17;
         for (uint32_t i=0; i<pBlockHeader->Num3DObjRec; i++)
@@ -588,7 +588,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
             //assert( pExtMesh );
 
             Block3DObj *pObj = (Block3DObj *)&pData[index]; index += 66;
-            if ( pExtMesh == NULL ) continue;
+            if ( pExtMesh == nullptr ) continue;
             int objID = pObj->ObjID1*100 + pObj->ObjID2;
 
             //finish the rest here....
@@ -602,7 +602,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
             uint16_t uTex = *((uint16_t *)&pData[index]); index += 2;
             index += 2; //unknown 1
             index++;    //unknown 2
-            if ( pExtMesh == NULL ) continue;
+            if ( pExtMesh == nullptr ) continue;
 
             //finish the rest here...
         }
@@ -619,7 +619,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
             uint16_t factionID = *((uint16_t *)&pData[index]); index += 2;
             index++;    //unknown
 
-            if ( pExtMesh == NULL ) continue;
+            if ( pExtMesh == nullptr ) continue;
 
             //finish the rest here...
         }
@@ -628,7 +628,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
             DoorData *pDoor = (DoorData *)&pData[index];
             index += 19;
 
-            if ( pExtMesh == NULL ) continue;
+            if ( pExtMesh == nullptr ) continue;
 
             //finish the rest here...
         }
@@ -1198,7 +1198,7 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
                         DT_ActionRecord *pActionRec = (DT_ActionRecord *)&pData[ obj3D.ActionOffset ];
                         
                         pMeshObj->action.nTargetOffs = pActionRec->TargetOffset;
-                        pMeshObj->action.pParent = NULL;
+                        pMeshObj->action.pParent = nullptr;
                         pMeshObj->action.Type = pActionRec->Type&0x0f;
                         pMeshObj->action.Axis = pActionRec->DataEntry[0];
                         pMeshObj->action.Duration = (float)( *((unsigned short *)&pActionRec->DataEntry[1]) ) / 16.0f;
@@ -1208,7 +1208,7 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
                     {
                         pMeshObj->action.Type = 0;
                         pMeshObj->action.nTargetOffs = -1;
-                        pMeshObj->action.pParent = NULL;
+                        pMeshObj->action.pParent = nullptr;
                         pMeshObj->action.Duration = 0;
                     }
                     */
@@ -1374,7 +1374,7 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
                             pObj->SetBoundingSphere(vLoc, sqrtf(vScale.x*vScale.x + vScale.z*vScale.z));
 
                             //texture index: 190 or 210 = lighting (emissive)
-                            //DungeonLight_t *pLight = NULL;
+                            //DungeonLight_t *pLight = nullptr;
                             static int8_t _bLit190[] = { 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0 };
                             static int8_t _bLit200[] = { 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
                             static int8_t _bLit202[] = { 0, 0, 1, 0, 0, 0, 0 };
@@ -1417,7 +1417,7 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
                             //
 
                             //texture index: 190 or 210 = lighting (emissive)
-                            DungeonLight_t *pLight = NULL;
+                            DungeonLight_t *pLight = nullptr;
                             if ( FileIndex == 190 || FileIndex == 210 )
                             {
                                 bEmissive = true;
@@ -1474,7 +1474,7 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
     if ( obj_root_offs )
     {
         ScratchPad::FreeFrame();
-        obj_root_offs = NULL;
+        obj_root_offs = nullptr;
     }
 
     //now resolve action records.
@@ -1647,13 +1647,13 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
             }
             if ( bMatchFound == false )
             {
-                pMesh->action.pTarget = NULL;
-                pMesh->action.pParent = NULL;
+                pMesh->action.pTarget = nullptr;
+                pMesh->action.pParent = nullptr;
             }
         }
         else
         {
-            pMesh->action.pTarget = NULL;
+            pMesh->action.pTarget = nullptr;
         }
     }
 #endif

--- a/fileformats/CellLoader_OutlawsMap.cpp
+++ b/fileformats/CellLoader_OutlawsMap.cpp
@@ -201,7 +201,7 @@ TextureHandle LoadNWX(uint8_t *pData, uint32_t uLen, const char *pszName, uint32
 
 WorldCell *CellLoader_OutlawsMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY )
 {
-    WorldCell *pCell = NULL;
+    WorldCell *pCell = nullptr;
     ObjectManager::FreeAllObjects();
     if ( uLen )
     {

--- a/fileformats/CellManager.cpp
+++ b/fileformats/CellManager.cpp
@@ -25,16 +25,16 @@ void CellManager::Destroy()
         {
             xlDelete m_CellLoaders[c];
         }
-        m_CellLoaders[c] = NULL;
+        m_CellLoaders[c] = nullptr;
     }
 }
 
 WorldCell *CellManager::LoadFromLocation(IDriver3D *pDriver, World *pWorld, uint32_t uCellType, void *pLocPtr)
 {
-    WorldCell *pCell = NULL;
+    WorldCell *pCell = nullptr;
 
     if ( uCellType >= CELLTYPE_COUNT )  //unsupported type.
-        return NULL;
+        return nullptr;
 
     CellLoader *pLoader = m_CellLoaders[uCellType];
 
@@ -49,16 +49,16 @@ WorldCell *CellManager::LoadFromLocation(IDriver3D *pDriver, World *pWorld, uint
 
 WorldCell *CellManager::LoadCell(IDriver3D *pDriver, World *pWorld, uint32_t uCellType, Archive *pCellArchive, const std::string& sFile, int32_t worldX, int32_t worldY)
 {
-    WorldCell *pCell = NULL;
+    WorldCell *pCell = nullptr;
 
     if ( uCellType >= CELLTYPE_COUNT )  //unsupported type.
-        return NULL;
+        return nullptr;
 
     CellLoader *pLoader = m_CellLoaders[uCellType];
 
     if ( pLoader->UsesOwnFiles() )
     {
-        pCell = pLoader->Load( pDriver, pWorld, NULL, 0, sFile, worldX, worldY );
+        pCell = pLoader->Load( pDriver, pWorld, nullptr, 0, sFile, worldX, worldY );
     }
     else if ( ArchiveManager::GameFile_Open(pCellArchive, sFile.c_str()) )
     {

--- a/fileformats/GOB_Reader.cpp
+++ b/fileformats/GOB_Reader.cpp
@@ -8,8 +8,8 @@
 GOB_Reader::GOB_Reader() : Archive()
 {
     m_CurFile = -1;
-    m_pFile = NULL;
-    m_FileList.pEntries = NULL;
+    m_pFile = nullptr;
+    m_FileList.pEntries = nullptr;
 }
 
 bool GOB_Reader::Open(const char *pszName)
@@ -65,7 +65,7 @@ bool GOB_Reader::Open(const char *pszName)
             }
 
             xlDelete [] pStringTable;
-            pStringTable = NULL;
+            pStringTable = nullptr;
         }
 
         fclose(f);
@@ -84,7 +84,7 @@ void GOB_Reader::Close()
     if ( m_FileList.pEntries )
     {
         xlDelete [] m_FileList.pEntries;
-        m_FileList.pEntries = NULL;
+        m_FileList.pEntries = nullptr;
     }
     m_bOpen = false;
 }
@@ -120,7 +120,7 @@ void GOB_Reader::CloseFile()
     if ( m_pFile )
     {
         fclose(m_pFile);
-        m_pFile = NULL;
+        m_pFile = nullptr;
     }
     m_CurFile = -1;
 }

--- a/fileformats/LFD_Reader.cpp
+++ b/fileformats/LFD_Reader.cpp
@@ -7,7 +7,7 @@
 LFD_Reader::LFD_Reader() : Archive()
 {
     m_CurFile = -1;
-    m_pFile = NULL;
+    m_pFile = nullptr;
 }
 
 bool LFD_Reader::Open(const char *pszName)
@@ -56,7 +56,7 @@ void LFD_Reader::Close()
     if ( m_FileList.pEntries )
     {
         xlDelete [] m_FileList.pEntries;
-        m_FileList.pEntries = NULL;
+        m_FileList.pEntries = nullptr;
     }
     m_bOpen = false;
 }
@@ -113,7 +113,7 @@ void LFD_Reader::CloseFile()
     if ( m_pFile )
     {
         fclose(m_pFile);
-        m_pFile = NULL;
+        m_pFile = nullptr;
     }
     m_CurFile = -1;
 }

--- a/fileformats/Location_Daggerfall.cpp
+++ b/fileformats/Location_Daggerfall.cpp
@@ -25,9 +25,9 @@ bool WorldMap::m_bMapLoaded = false;
 Location_Daggerfall::Location_Daggerfall()
 {
     m_bLoaded           = false;
-    m_pBlockNames       = NULL;
-    m_pDungeonBlocks    = NULL;
-    m_pTexData          = NULL;
+    m_pBlockNames       = nullptr;
+    m_pDungeonBlocks    = nullptr;
+    m_pTexData          = nullptr;
     m_dungeonBlockCnt   = 0;
     m_startDungeonBlock = 0;
 }
@@ -121,7 +121,7 @@ bool Location_Daggerfall::Load(FILE *f, std::map<uint64_t, Location_Daggerfall *
 ///////////////////////////////////////////////////////
 Region_Daggerfall::Region_Daggerfall()
 {
-    m_pLocations = NULL;
+    m_pLocations = nullptr;
 }
 
 Region_Daggerfall::~Region_Daggerfall()
@@ -157,7 +157,7 @@ bool Region_Daggerfall::Load(FILE *f, std::map<uint64_t, Location_Daggerfall *>&
 ///////////////////////////////////////////////////////
 void WorldMap::Init()
 {
-    m_pRegions = NULL;
+    m_pRegions = nullptr;
 }
 
 void WorldMap::Destroy()
@@ -175,7 +175,7 @@ bool WorldMap::Load()
 
     // TODO: Disabled until a proper cache location can be handled.
     bool bSuccess;
-    FILE *f = NULL;//fopen(szCachedFile, "rb");
+    FILE *f = nullptr;//fopen(szCachedFile, "rb");
     if ( f )
     {
         int version;
@@ -210,7 +210,7 @@ bool WorldMap::Load()
 void WorldMap::Save()
 {
     // TODO: Disabled until a proper cache location can be handled.
-    FILE *f = NULL;//fopen(szCachedFile, "wb");
+    FILE *f = nullptr;//fopen(szCachedFile, "wb");
     if ( f )
     {
         int version = CACHED_FILE_VERSION;
@@ -377,7 +377,7 @@ bool WorldMap::Cache()
         if ( ArchiveManager::GameFile_Open(ARCHIVETYPE_BSA, "MAPS.BSA", szFileName) )
         {
             m_pRegions[r].m_uLocationCount = 0;
-            m_pRegions[r].m_pLocations     = NULL;
+            m_pRegions[r].m_pLocations     = nullptr;
 
             uint32_t uLength = ArchiveManager::GameFile_GetLength();
             if ( uLength == 0 )
@@ -455,7 +455,7 @@ bool WorldMap::Cache()
                 {
                     index = base_index + offsets[i];
                     int nPreRecCount = *((int *)&pData[index]); index += 4;
-                    uint8_t *PreRecords = NULL;
+                    uint8_t *PreRecords = nullptr;
                     if ( nPreRecCount > 0 )
                     {
                         PreRecords = (uint8_t *)&pData[index]; index += nPreRecCount*6;
@@ -474,7 +474,7 @@ bool WorldMap::Cache()
 
                     m_pRegions[r].m_pLocations[i].m_BlockWidth  = 0;
                     m_pRegions[r].m_pLocations[i].m_BlockHeight = 0;
-                    m_pRegions[r].m_pLocations[i].m_pBlockNames = NULL;
+                    m_pRegions[r].m_pLocations[i].m_pBlockNames = nullptr;
 
                     if ( pLocation->LocType == 0x00008000 )
                     {
@@ -587,7 +587,7 @@ bool WorldMap::Cache()
                     index = base_index + pOffsets[i].Offset;
 
                     //find matching exterior record...
-                    Location_Daggerfall *pCurLoc=NULL;
+                    Location_Daggerfall *pCurLoc=nullptr;
                     for (int e=0; e<(int)m_pRegions[r].m_uLocationCount; e++)
                     {
                         if ( m_pRegions[r].m_pLocations[e].m_LocationID == pOffsets[i].ExteriorLocID )
@@ -599,7 +599,7 @@ bool WorldMap::Cache()
                     assert(pCurLoc);
 
                     int nPreRecCount = *((int *)&pData[index]); index += 4;
-                    uint8_t *PreRecords = NULL;
+                    uint8_t *PreRecords = nullptr;
                     if ( nPreRecCount > 0 )
                     {
                         PreRecords = (uint8_t *)&pData[index]; index += nPreRecCount*6;
@@ -664,7 +664,7 @@ bool WorldMap::Cache()
 
 Location_Daggerfall *WorldMap::GetLocation(int32_t x, int32_t y)
 {
-    Location_Daggerfall *pLoc = NULL;
+    Location_Daggerfall *pLoc = nullptr;
 
     uint64_t uKey = (uint64_t)y<<32ULL | (uint64_t)x;
     std::map<uint64_t, Location_Daggerfall *>::iterator iLoc = m_MapLoc.find(uKey);
@@ -678,7 +678,7 @@ Location_Daggerfall *WorldMap::GetLocation(int32_t x, int32_t y)
 
 Location_Daggerfall *WorldMap::GetLocation(const char *pszName)
 {
-    Location_Daggerfall *pLoc = NULL;
+    Location_Daggerfall *pLoc = nullptr;
 
     std::map<std::string, Location_Daggerfall *>::iterator iLoc = m_MapNames.find(pszName);
     if ( iLoc != m_MapNames.end() )
@@ -697,7 +697,7 @@ void WorldMap::SetWorldCell(int32_t x, int32_t y, WorldCell *pCell)
 
 WorldCell *WorldMap::GetWorldCell(int32_t x, int32_t y)
 {
-    WorldCell *pCell = NULL;
+    WorldCell *pCell = nullptr;
     uint64_t uKey = (uint64_t)y<<32ULL | (uint64_t)x;
     std::map<uint64_t, WorldCell *>::iterator iLoc = m_MapCell.find(uKey);
 

--- a/fileformats/MeshLoader_Daggerfall.cpp
+++ b/fileformats/MeshLoader_Daggerfall.cpp
@@ -371,7 +371,7 @@ bool MeshLoader_Daggerfall::LoadMesh(IDriver3D *pDriver, Mesh *pMesh, MeshCollis
 
         if ( polygons[i].header.nPlanePointCount < 3 )
         {
-            polygons[i].points = NULL;
+            polygons[i].points = nullptr;
             polygons[i].header.nPlanePointCount = 0;
             continue;
         }
@@ -414,7 +414,7 @@ bool MeshLoader_Daggerfall::LoadMesh(IDriver3D *pDriver, Mesh *pMesh, MeshCollis
         }
         else
         {
-            polygons[i].points = NULL;
+            polygons[i].points = nullptr;
             polygons[i].hTex = 0;
             w = 64; h = 64;
             polygons[i].vUVScale.x = 1.0f / (16.0f * (float)w);

--- a/fileformats/RFF_Reader.cpp
+++ b/fileformats/RFF_Reader.cpp
@@ -52,9 +52,9 @@ struct FileInfo
 RFF_Reader::RFF_Reader() : Archive()
 {
     m_CurFile = -1;
-    m_pFile = NULL;
-    m_pFileLocal = NULL;
-    m_pFileList = NULL;
+    m_pFile = nullptr;
+    m_pFileLocal = nullptr;
+    m_pFileList = nullptr;
     m_uFileCount = 0;
     m_bEncrypt = false;
 }
@@ -156,9 +156,9 @@ FILE *OpenFile_Local(const char *pszFile)
 //This is different then other archives, we're reading indices here...
 bool RFF_Reader::OpenFile(const char *pszFile)
 {
-    if((m_pFileLocal=OpenFile_Local(pszFile)) != NULL)
+    if((m_pFileLocal=OpenFile_Local(pszFile)) != nullptr)
     {
-        m_pFile = NULL;
+        m_pFile = nullptr;
         return true;
     }
 
@@ -191,14 +191,14 @@ void RFF_Reader::CloseFile()
     if ( m_pFileLocal )
     {
         fclose(m_pFileLocal);
-        m_pFileLocal = NULL;
+        m_pFileLocal = nullptr;
         return;
     }
 
     if ( m_pFile )
     {
         fclose(m_pFile);
-        m_pFile = NULL;
+        m_pFile = nullptr;
     }
     m_CurFile = -1;
 }
@@ -249,7 +249,7 @@ bool RFF_Reader::ReadFile(void *pData, uint32_t uLength)
 //This is needed for this particular archive because it contains size info for the tile.
 void *RFF_Reader::ReadFileInfo()
 {
-    return NULL;
+    return nullptr;
 }
 
 int32_t RFF_Reader::GetFileCount()

--- a/fileformats/SkyLoader_Daggerfall.cpp
+++ b/fileformats/SkyLoader_Daggerfall.cpp
@@ -111,7 +111,7 @@ bool SkyLoader_Daggerfall::LoadSky(int32_t regionID)
 
 void *SkyLoader_Daggerfall::GetSkyData(int32_t regionID)
 {
-    void *pData = NULL;
+    void *pData = nullptr;
     if ( m_aSkyData[regionID].bLoaded )
     {
         pData = &m_aSkyData[regionID];

--- a/fileformats/TextureConv_IMG.cpp
+++ b/fileformats/TextureConv_IMG.cpp
@@ -84,8 +84,8 @@ uint32_t TextureConv_IMG::GetHackID(const char *pszImage)
 bool TextureConv_IMG::ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID/*=0*/)
 {
     ImageHeader header;
-    uint8_t *pImageData=NULL;
-    uint8_t *pCustomPal=NULL;
+    uint8_t *pImageData=nullptr;
+    uint8_t *pCustomPal=nullptr;
     int nPal = PAL_PAL;
     nOffsX = 0;
     nOffsY = 0;
@@ -241,7 +241,7 @@ bool TextureConv_IMG::ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOff
         int pitch = header.Width;
 
         //now we'll create an RGBA texture and create a hardware texture out of it.
-        uint8_t *pal = NULL;
+        uint8_t *pal = nullptr;
         uint32_t palStride = 3;
         if ( pCustomPal )
         {
@@ -392,7 +392,7 @@ bool TextureConv_IMG::ConvertTexture_Pal8_TexList(uint8_t *pConvertedData, int32
     TexRecord *pRec = (TexRecord *)&pSourceData[index];
     bool bCompressed = (pRec->compression == Ctx_RleCompressed || pRec->compression == Ctx_ImageRle || pRec->compression == Ctx_RecordRle);
     index = pHeaders[ nRecord ].recordPos + (int32_t)pRec->dataOffs;
-    uint8_t *buffer = NULL;
+    uint8_t *buffer = nullptr;
 
     nOffsX  = (int32_t)pRec->offsetX;
     nOffsY  = (int32_t)pRec->offsetY;
@@ -564,8 +564,8 @@ bool TextureConv_IMG::ConvertTexture_Pal8_TexList(uint8_t *pConvertedData, int32
 bool TextureConv_IMG::ConvertTexture_8bpp(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, uint32_t uHackID/*=0*/)
 {
     ImageHeader header;
-    uint8_t *pImageData=NULL;
-    uint8_t *pCustomPal=NULL;
+    uint8_t *pImageData=nullptr;
+    uint8_t *pCustomPal=nullptr;
     int nPal = PAL_PAL;
     nOffsX = 0;
     nOffsY = 0;
@@ -744,7 +744,7 @@ uint32_t TextureConv_IMG::ConvertTexture_8bpp_TexList(uint8_t *pConvertedData, i
     TexRecord *pRec = (TexRecord *)&pSourceData[index];
     bool bCompressed = (pRec->compression == Ctx_RleCompressed || pRec->compression == Ctx_ImageRle || pRec->compression == Ctx_RecordRle);
     index = pHeaders[ nRecord ].recordPos + (int32_t)pRec->dataOffs;
-    uint8_t *buffer = NULL;
+    uint8_t *buffer = nullptr;
 
     nOffsX  = (int32_t)pRec->offsetX;
     nOffsY  = (int32_t)pRec->offsetY;

--- a/fileformats/TextureLoader.cpp
+++ b/fileformats/TextureLoader.cpp
@@ -22,14 +22,14 @@ uint32_t TextureLoader::m_uWidth;
 uint32_t TextureLoader::m_uHeight;
 uint32_t TextureLoader::m_uExtraDataSize=0;
 uint32_t TextureLoader::m_uTexColorDepth=32;
-void *TextureLoader::m_pTexExtraData=NULL;
+void *TextureLoader::m_pTexExtraData=nullptr;
 Palette TextureLoader::m_CurPal[MAX_PAL_COUNT];
 Colormap TextureLoader::m_ColorMap[MAX_COLORMAP_COUNT];
 
 void TextureLoader::Init()
 {
-    m_pCurConverter=NULL;
-    m_pConvertedData=NULL;
+    m_pCurConverter=nullptr;
+    m_pConvertedData=nullptr;
 
     //create the texture converter list here.
     m_TextureConverters[TEXTURETYPE_ART] = xlNew TextureConv_ART();
@@ -45,9 +45,9 @@ void TextureLoader::Destroy()
         {
             xlDelete m_TextureConverters[c];
         }
-        m_TextureConverters[c] = NULL;
+        m_TextureConverters[c] = nullptr;
     }
-    m_pCurConverter=NULL;
+    m_pCurConverter=nullptr;
 }
 
 bool TextureLoader::LoadTexture(uint32_t uTextureType, uint32_t uPalIndex, Archive *pTexArchive, const std::string& sFile, bool bCopyPal)
@@ -228,7 +228,7 @@ bool TextureLoader::LoadTexture_Mem(const uint8_t *pImgBuffer, uint32_t uPalInde
     uint32_t uDataSize = width*height;
     if ( m_uTexColorDepth == 32 ) uDataSize *= 4;
     m_pConvertedData = (uint8_t *)ScratchPad::AllocMem( uDataSize );
-    if ( !(m_pConvertedData != NULL) )
+    if ( !(m_pConvertedData != nullptr) )
         return false;
 
     if ( m_uTexColorDepth == 32 )
@@ -269,7 +269,7 @@ uint8_t *TextureLoader::GetData_RGBA8()
 void TextureLoader::FreeData()
 {
     ScratchPad::FreeFrame();
-    m_pConvertedData = NULL;
+    m_pConvertedData = nullptr;
 }
 
 void TextureLoader::SetPalette(uint8_t uPalIndex, uint8_t *pData, uint32_t uSize, uint32_t uTransparentIndex)

--- a/linux/main.cpp
+++ b/linux/main.cpp
@@ -46,7 +46,7 @@ void checkSDLError(int ret)
 
 int main(int argc, char **argv)
 {
-    const char *game_name = NULL;
+    const char *game_name = nullptr;
 
     for(int i = 1;i < argc;i++)
     {
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
     }
 
     delete m_pEngine;
-    m_pEngine = NULL;
+    m_pEngine = nullptr;
 
     SDL_GL_MakeCurrent(0, 0);
     SDL_GL_DeleteContext(glctx);

--- a/memory/ScratchPad.cpp
+++ b/memory/ScratchPad.cpp
@@ -7,7 +7,7 @@
 #define SCRATCH_PAD_SIZE 64*1024*1024
 #define MAX_FRAME_COUNT 128
 
-uint8_t *ScratchPad::m_pMemory=NULL;
+uint8_t *ScratchPad::m_pMemory=nullptr;
 uint32_t ScratchPad::m_uFramePtr=0;
 
 int32_t ScratchPad::m_nCurFrame;
@@ -28,7 +28,7 @@ void ScratchPad::Destroy()
     {
         xlDelete [] m_pMemory;
     }
-    m_pMemory = NULL;
+    m_pMemory = nullptr;
 }
 
 void ScratchPad::StartFrame()
@@ -46,7 +46,7 @@ void *ScratchPad::AllocMem(uint32_t uSize)
     if ( m_uFramePtr + uSize >= SCRATCH_PAD_SIZE )
     {
         assert(0);
-        return NULL;
+        return nullptr;
     }
 
     uint32_t uLoc = m_uFramePtr;

--- a/movieplayback/LFD_Film.cpp
+++ b/movieplayback/LFD_Film.cpp
@@ -67,7 +67,7 @@ LFD_Film::LFD_Film(IDriver3D *pDriver) : MoviePlayer(pDriver)
     m_nCut = -1;
     m_fCutTime = 0.0f;
     m_fCurCutTime = 0.0f;
-    m_Commands = NULL;
+    m_Commands = nullptr;
 }
 
 void LFD_Film::Stop()
@@ -102,7 +102,7 @@ void LFD_Film::Stop()
             m_Commands[i].commands.clear();
         }
         xlDelete [] m_Commands;
-        m_Commands = NULL;
+        m_Commands = nullptr;
     }
 
 
@@ -378,11 +378,11 @@ bool LFD_Film::Start(Archive *pRes0, Archive *pRes1, const char *pszFile, uint32
         switch (pEntry->nBlockType)
         {
             case BTYPE_VIEW:
-                pFile = NULL;
+                pFile = nullptr;
                 m_nEntry = BTYPE_VIEW;
             break;
             case BTYPE_VOIC:
-                pFile = NULL;
+                pFile = nullptr;
                 m_nEntry = BTYPE_VOIC;
 
                 memcpy(szName, pEntry->szName, 8);
@@ -427,7 +427,7 @@ bool LFD_Film::Start(Archive *pRes0, Archive *pRes1, const char *pszFile, uint32
             }
             break;
             case BTYPE_DELT_ANIM_CUST:
-                pFile = NULL;
+                pFile = nullptr;
                 m_nEntry = BTYPE_DELT_ANIM_CUST;
                 if ( pEntry->szType[0] == 'D' && pEntry->szType[1] == 'E' && pEntry->szType[2] == 'L' && pEntry->szType[3] == 'T' )
                 {
@@ -928,7 +928,7 @@ void LFD_Film::StartCut(int how, int type)
 
 void LFD_Film::AddGraphicToQueue(Graphic *pGraphic, int nLayer)
 {
-    pGraphic->pNext = NULL;
+    pGraphic->pNext = nullptr;
     if ( nLayer < 0 ) { nLayer = 0; }
     if ( nLayer > 201 ) { nLayer = 201; }
 
@@ -966,7 +966,7 @@ void LFD_Film::Render(float fDeltaTime)
     int32_t i;
     for (i=0; i<202; i++)
     {
-        m_apAnimQueue[i] = NULL;
+        m_apAnimQueue[i] = nullptr;
     }
 
     //render all the graphics that are visible...

--- a/movieplayback/MovieManager.cpp
+++ b/movieplayback/MovieManager.cpp
@@ -13,9 +13,9 @@ IDriver3D *MovieManager::m_pDriver;
 
 void MovieManager::Init(IDriver3D *pDriver)
 {
-    m_pCurPlayer=NULL;
-    m_apArchives[0] = NULL;
-    m_apArchives[1] = NULL;
+    m_pCurPlayer=nullptr;
+    m_apArchives[0] = nullptr;
+    m_apArchives[1] = nullptr;
     m_pDriver = pDriver;
 }
 
@@ -37,7 +37,7 @@ void MovieManager::SetPlayerType(uint32_t uPlayerType)
     if ( m_pCurPlayer )
     {
         m_pCurPlayer->Stop();
-        m_pCurPlayer = NULL;
+        m_pCurPlayer = nullptr;
     }
 
     switch (uPlayerType)
@@ -58,8 +58,8 @@ void MovieManager::SetPlayerType(uint32_t uPlayerType)
 
 void MovieManager::SetPlayerArchives(uint32_t uArchiveType, const char *pszArchive0, const char *pszArchive1)
 {
-    m_apArchives[0] = NULL;
-    m_apArchives[1] = NULL;
+    m_apArchives[0] = nullptr;
+    m_apArchives[1] = nullptr;
     if ( pszArchive0 && pszArchive0[0] )
     {
         m_apArchives[0] = ArchiveManager::OpenArchive(uArchiveType, pszArchive0);

--- a/networking/NetworkMgr.cpp
+++ b/networking/NetworkMgr.cpp
@@ -8,9 +8,9 @@
 
 #define MAX_PLAYERS 32
 
-ENetHost *_pServer = NULL;
-ENetHost *_pClient = NULL;
-ENetPeer *_pServerPeer = NULL;
+ENetHost *_pServer = nullptr;
+ENetHost *_pClient = nullptr;
+ENetPeer *_pServerPeer = nullptr;
 
 struct NetworkPlayer
 {
@@ -100,7 +100,7 @@ void NetworkMgr::Destroy()
     if ( _pServer )
     {
         enet_host_destroy(_pServer);
-        _pServer = NULL;
+        _pServer = nullptr;
     }
     if ( _pClient )
     {
@@ -134,11 +134,11 @@ void NetworkMgr::Destroy()
         {
             //force the disconnection.
             enet_peer_reset(_pServerPeer);
-            _pServerPeer = NULL;
+            _pServerPeer = nullptr;
         }
 
         enet_host_destroy(_pClient);
-        _pClient = NULL;
+        _pClient = nullptr;
     }
     enet_deinitialize();
 }
@@ -183,7 +183,7 @@ bool NetworkMgr::CreateServer()
         enet_address_set_host(&address, pszServerIP);
     }
 
-    if (_pServer == NULL)
+    if (_pServer == nullptr)
     {
         XL_Console::PrintF("^1Error: An error occurred while trying to create an ENet server host.");
         return false;
@@ -198,9 +198,9 @@ bool NetworkMgr::CreateClient()
     uint32_t uChannelCount = 1;
     uint32_t uIncomingBandwidth = 57600 / 8;    //56K modem with 56 Kbps downstream bandwidth
     uint32_t uOutgoingBandwidth = 14400 / 8; //56K modem with 14 Kbps upstream bandwidth
-    _pClient = enet_host_create(NULL, 1, uChannelCount, uIncomingBandwidth, uOutgoingBandwidth);
+    _pClient = enet_host_create(nullptr, 1, uChannelCount, uIncomingBandwidth, uOutgoingBandwidth);
 
-    if (_pClient == NULL)
+    if (_pClient == nullptr)
     {
         XL_Console::PrintF("^1Error: An error occurred while trying to create an ENet client host.");
         return false;
@@ -217,7 +217,7 @@ bool NetworkMgr::CreateClient()
 
     /* Initiate the connection, allocating the two channels 0 and 1. */
     _pServerPeer = enet_host_connect(_pClient, &address, 2, 0);    
-    if (_pServerPeer == NULL)
+    if (_pServerPeer == nullptr)
     {
         XL_Console::PrintF("^1Error: No available peers for initiating an ENet connection.");
         return false;
@@ -291,7 +291,7 @@ void NetworkMgr::SetLocalPlayerName(const char *pszName)
 
 void NetworkMgr::SendPacket_Client(uint32_t uChannel, const uint8_t *data, uint32_t uDataSize)
 {
-    if ( _pServerPeer == NULL )
+    if ( _pServerPeer == nullptr )
         return;
 
     ENetPacket *packet = enet_packet_create(data, uDataSize, ENET_PACKET_FLAG_RELIABLE);
@@ -417,7 +417,7 @@ void NetworkMgr::_ServerLoop()
                     }
                 }
                 /* Reset the peer's client information. */
-                event.peer->data = NULL;
+                event.peer->data = nullptr;
             break;
 
             case ENET_EVENT_TYPE_NONE:
@@ -469,8 +469,8 @@ void NetworkMgr::_ClientLoop()
                 Vector4 red(1.0f, 0.0f, 0.0f, 1.0f);
                 m_pEngine->AddDisplayMessage( "You have been disconnected.", &red, 1000.0f );
                 /* Reset the peer's client information. */
-                event.peer->data = NULL;
-                _pServerPeer = NULL;
+                event.peer->data = nullptr;
+                _pServerPeer = nullptr;
             }
             break;
 

--- a/os/Input.cpp
+++ b/os/Input.cpp
@@ -124,7 +124,7 @@ void Input::SetMousePos(float x, float y)
 bool Input::AddKeyDownCallback(Input_KeyDownCB pCB, int32_t nFlags)
 {
     KeyDownCB_t *pKeyDownCB = xlNew KeyDownCB_t;
-    if (pKeyDownCB == NULL)
+    if (pKeyDownCB == nullptr)
         return false;
 
     pKeyDownCB->pCB    = pCB;
@@ -137,7 +137,7 @@ bool Input::AddKeyDownCallback(Input_KeyDownCB pCB, int32_t nFlags)
 bool Input::AddCharDownCallback( Input_KeyDownCB pCB )
 {
     KeyDownCB_t *pCharDownCB = xlNew KeyDownCB_t;
-    if (pCharDownCB == NULL)
+    if (pCharDownCB == nullptr)
         return false;
 
     pCharDownCB->pCB    = pCB;

--- a/plugin_framework/DynamicLibrary.cpp
+++ b/plugin_framework/DynamicLibrary.cpp
@@ -40,10 +40,10 @@ DynamicLibrary *DynamicLibrary::Load(const std::string& name, std::string& error
     if (name.empty()) 
     {
         errorString = "Empty path.";
-        return NULL;
+        return nullptr;
     }
 
-    void *handle = NULL;
+    void *handle = nullptr;
     std::string path = name + "." + dynamicLibraryExtension;
 
 #if PLATFORM_WIN
@@ -57,7 +57,7 @@ DynamicLibrary *DynamicLibrary::Load(const std::string& name, std::string& error
            << errorCode; 
         errorString = ss.str();
 
-        return NULL;
+        return nullptr;
     }
 #else
     handle = dlopen( path.c_str(), RTLD_NOW );
@@ -72,7 +72,7 @@ DynamicLibrary *DynamicLibrary::Load(const std::string& name, std::string& error
         if(dlErrorString.size())
             errorString += ": " + dlErrorString;
 
-        return NULL;
+        return nullptr;
     }
 #endif
 
@@ -82,7 +82,7 @@ DynamicLibrary *DynamicLibrary::Load(const std::string& name, std::string& error
 void *DynamicLibrary::GetSymbol(const std::string& symbol)
 {
     if ( !m_handle )
-        return NULL;
+        return nullptr;
 
 #if PLATFORM_WIN
     return GetProcAddress( (HMODULE)m_handle, symbol.c_str() );

--- a/plugin_framework/PluginManager.cpp
+++ b/plugin_framework/PluginManager.cpp
@@ -9,8 +9,8 @@ XL_ExitFunc m_ExitFunc;
 
 bool PluginManager::Init(XLEngine_Plugin_API *pluginAPI)
 {
-    m_pGameLib = NULL;
-    m_ExitFunc = NULL;
+    m_pGameLib = nullptr;
+    m_ExitFunc = nullptr;
     m_pAPI = pluginAPI;
 
     return true;
@@ -50,11 +50,11 @@ void PluginManager::UnloadGame()
     if ( m_ExitFunc )
     {
         m_ExitFunc();
-        m_ExitFunc = NULL;
+        m_ExitFunc = nullptr;
     }
     if ( m_pGameLib )
     {
         xlDelete m_pGameLib;
-        m_pGameLib = NULL;
+        m_pGameLib = nullptr;
     }
 }

--- a/plugin_framework/plugin.h
+++ b/plugin_framework/plugin.h
@@ -18,12 +18,12 @@ typedef int32_t (*XL_ExitFunc)();
 /** Type definition of the XL_initPlugin function below (used by PluginManager to initialize plugins)
  * Note the return type is the XL_ExitFunc (used by PluginManager to tell plugins to cleanup). If 
  * the initialization failed for any reason the plugin may report the error via the error reporting
- * function of the provided platform services. Nevertheless, it must return NULL exit func in this case
+ * function of the provided platform services. Nevertheless, it must return null exit func in this case
  * to let the plugin manger that the plugin wasn't initialized properly. The plugin may use the runtime
  * services - allocate memory, log messages and of course register node types.
  *
  * @param  [const XL_PlatformServices *] params - the platform services struct 
- * @retval [XL_ExitFunc] the exit func of the plugin or NULL if initialization failed.
+ * @retval [XL_ExitFunc] the exit func of the plugin or null if initialization failed.
  */
 typedef XL_ExitFunc (*XL_InitFunc)(const XLEngine_Plugin_API *);
 
@@ -38,7 +38,7 @@ typedef XL_ExitFunc (*XL_InitFunc)(const XLEngine_Plugin_API *);
  * (and conform to the signature of course).
  *
  * @param  [const XL_PlatformServices *] params - the platform services struct 
- * @retval [XL_ExitFunc] the exit func of the plugin or NULL if initialization failed.
+ * @retval [XL_ExitFunc] the exit func of the plugin or null if initialization failed.
  */
 
 #ifndef PLUGIN_API

--- a/render/CommandBuffer.cpp
+++ b/render/CommandBuffer.cpp
@@ -30,7 +30,7 @@ void CommandBuffer::Destroy()
     for (int c=0; c<CommandBuffer::BUFFER_COUNT; c++)
     {
         delete s_pCommandBuffer[c];
-        s_pCommandBuffer[c] = NULL;
+        s_pCommandBuffer[c] = nullptr;
     }
 }
 
@@ -102,7 +102,7 @@ void CommandBuffer::DrawCall(const Matrix& mWorld, TextureHandle hTex, VertexBuf
 //Custom command, returns memory allocated from the command buffer.
 void *CommandBuffer::CB_Command(uint32_t uSize)
 {
-    void *pMem = NULL;
+    void *pMem = nullptr;
     if ( s_uCommandPos+uSize+END_MARKER_SIZE <= BUFFER_SIZE )
     {
         pMem = &s_pCommandBuffer[s_uWriteBuffer];

--- a/render/Driver3D_OGL.cpp
+++ b/render/Driver3D_OGL.cpp
@@ -15,7 +15,7 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 
-#define BUFFER_OFFSET(i) ((char *)NULL + (i))
+#define BUFFER_OFFSET(i) ((char *)nullptr + (i))
 
 uint32_t _uPrevVBO = 0xffffffff;
 uint32_t _uBlendFunc = 0;
@@ -49,7 +49,7 @@ bool _bFogEnable = false;
 float _fFogDensity = 1.0f;
 float _fFogEnd = 0.0f;
 
-Matrix *_prevWorldMtxPtr = NULL;
+Matrix *_prevWorldMtxPtr = nullptr;
 
 Vector4 _prevColor(1.0f, 1.0f, 1.0f, 1.0f);
 
@@ -267,9 +267,9 @@ void Driver3D_OGL::Clear(bool bClearColor)
 
 void Driver3D_OGL::SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY)
 {
-    if ( pMtx == NULL )
+    if ( pMtx == nullptr )
     {
-        _prevWorldMtxPtr = NULL;
+        _prevWorldMtxPtr = nullptr;
     }
     else if ( pMtx != _prevWorldMtxPtr )
     {
@@ -288,7 +288,7 @@ void Driver3D_OGL::SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir)
     m_ViewMtx = *pMtx;
     m_Eye = *pLoc;
     m_ViewDir = *pDir;
-    _prevWorldMtxPtr = NULL;    //reset so the world matrix applies the proper transform.
+    _prevWorldMtxPtr = nullptr;    //reset so the world matrix applies the proper transform.
 }
 
 void Driver3D_OGL::SetProjMtx(Matrix *pMtx)
@@ -349,7 +349,7 @@ void Driver3D_OGL::SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter
 
 void Driver3D_OGL::SetColor(Vector4 *pColor)
 {
-    if ( pColor == NULL ) pColor = &Vector4::One;
+    if ( pColor == nullptr ) pColor = &Vector4::One;
 
     if ( *pColor != _prevColor )
     {
@@ -358,7 +358,7 @@ void Driver3D_OGL::SetColor(Vector4 *pColor)
     }
 }
 
-TextureHandle Driver3D_OGL::CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat/*=TEX_FORMAT_RGBA8*/, uint8_t *pData/*=NULL*/, bool bGenMips/*=false*/, int32_t nFrameCnt/*=1*/)
+TextureHandle Driver3D_OGL::CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat/*=TEX_FORMAT_RGBA8*/, uint8_t *pData/*=nullptr*/, bool bGenMips/*=false*/, int32_t nFrameCnt/*=1*/)
 {
     GLint internalFormat=GL_RGBA8;
     GLenum type=GL_UNSIGNED_BYTE;
@@ -573,7 +573,7 @@ uint32_t Driver3D_OGL::CreateVBO()
 void Driver3D_OGL::AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic)
 {
     if ( uID != _uBindBufferVB ) { glBindBuffer(GL_ARRAY_BUFFER, uID); _uBindBufferVB = uID; }
-    glBufferData(GL_ARRAY_BUFFER, uSize, NULL, bDynamic ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, uSize, nullptr, bDynamic ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     _uBindBufferVB = 0;
 }
@@ -582,8 +582,8 @@ void Driver3D_OGL::FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDyna
 {
     if ( uID != _uBindBufferVB ) { glBindBuffer(GL_ARRAY_BUFFER, uID); _uBindBufferVB = uID; }
 
-    //cause the "discard" buffer behavior, which is done by first calling glBufferData() with NULL data.
-    glBufferData(GL_ARRAY_BUFFER, uSize, NULL, bDynamic ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
+    //cause the "discard" buffer behavior, which is done by first calling glBufferData() with null data.
+    glBufferData(GL_ARRAY_BUFFER, uSize, nullptr, bDynamic ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
     //now lock and update the buffer.
     void *pMem = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
     if ( pMem )

--- a/render/Driver3D_Soft.cpp
+++ b/render/Driver3D_Soft.cpp
@@ -27,12 +27,12 @@
 #include <GL/glu.h>
 
 #define TEST_COLORMAP 0
-#define BUFFER_OFFSET(i) ((char *)NULL + (i))
+#define BUFFER_OFFSET(i) ((char *)nullptr + (i))
 
 Texture *Driver3D_Soft::m_pCurTex;
 uint32_t Driver3D_Soft::s_uColormapID;
 
-Matrix *_prevWorldMtxPtr_Soft = NULL;
+Matrix *_prevWorldMtxPtr_Soft = nullptr;
 int32_t _prevWorldX = 0;
 int32_t _prevWorldY = 0;
 uint32_t *m_pFrameBuffer_32bpp;
@@ -52,7 +52,7 @@ float m_QuadHeightScale = 1.0f;
 float m_fTexAnimFrameRate = 8.0f;
 
 int32_t _trianglesPerFrame = 0;
-static uint32_t *_pCurPal = NULL;
+static uint32_t *_pCurPal = nullptr;
 
 //#define MAX_FRAMEBUFFER_WIDTH 2048
 #define MAX_FRAMEBUFFER_WIDTH 1024
@@ -63,8 +63,8 @@ void *aligned_malloc(size_t size, size_t align_size)
     int align_mask = (int)align_size-1;
 
     ptr = (char *)malloc( size + align_size + sizeof(int) );
-    if ( ptr == NULL)
-        return NULL;
+    if ( ptr == nullptr)
+        return nullptr;
 
     ptr2 = ptr + sizeof(int);
     aligned_ptr = ptr2 + ( align_size - ((size_t)ptr2 & align_mask) );
@@ -88,11 +88,11 @@ void aligned_free(void *ptr)
 Driver3D_Soft::Driver3D_Soft() : IDriver3D()
 {
     m_nBitDepth = 32;
-    m_pCurVBO   = NULL;
-    m_pTexArray = NULL;
-    m_pTexIndex = NULL;
-    m_pRenderCamera = NULL;
-    m_pCurPolygonData = NULL;
+    m_pCurVBO   = nullptr;
+    m_pTexArray = nullptr;
+    m_pTexIndex = nullptr;
+    m_pRenderCamera = nullptr;
+    m_pCurPolygonData = nullptr;
     m_bBilinear = false;
     m_bGouraud  = false;
     m_uClearColor = 0;
@@ -241,7 +241,7 @@ bool Driver3D_Soft::Init(int32_t w, int32_t h)
     if ( m_nBitDepth == 32 )
     {
         m_pFrameBuffer_32bpp = (uint32_t *)aligned_malloc( m_FrameWidth*m_FrameHeight*sizeof(uint32_t), 16 );
-        m_pFrameBuffer_8bpp  = NULL;
+        m_pFrameBuffer_8bpp  = nullptr;
     }
     else
     {
@@ -272,7 +272,7 @@ bool Driver3D_Soft::Init(int32_t w, int32_t h)
     DrawScanline::_nFrameWidth   = m_FrameWidth;
     DrawScanline::_nFrameHeight  = m_FrameHeight;
     DrawScanline::_uColormapID   = s_uColormapID;
-    DrawScanline::_pCurTex       = NULL;
+    DrawScanline::_pCurTex       = nullptr;
     DrawScanline::_pFrameBuffer_32 = m_pFrameBuffer_32bpp;
     DrawScanline::_pFrameBuffer_8  = m_pFrameBuffer_8bpp;
     DrawScanline::_pDepthBuffer    = m_pDepthBuffer;
@@ -536,7 +536,7 @@ void Driver3D_Soft::Present()
     //if ( m_nBitDepth == 8 )
     {
         static uint32_t _palIdx = 0xffffffff;
-        if ( _pCurPal == NULL || _palIdx != m_uPaletteID || m_bUpdatePal )
+        if ( _pCurPal == nullptr || _palIdx != m_uPaletteID || m_bUpdatePal )
         {
             uint8_t *pal = TextureLoader::GetPaletteData(m_uPaletteID);
             int index = 0;
@@ -632,9 +632,9 @@ void Driver3D_Soft::Clear(bool bClearColor)
 
 void Driver3D_Soft::SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY)
 {
-    if ( pMtx == NULL )
+    if ( pMtx == nullptr )
     {
-        _prevWorldMtxPtr_Soft = NULL;
+        _prevWorldMtxPtr_Soft = nullptr;
     }
     else if ( pMtx != _prevWorldMtxPtr_Soft || worldX != _prevWorldX || worldY != _prevWorldY )
     {
@@ -659,7 +659,7 @@ void Driver3D_Soft::SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir)
     m_ViewMtx = *pMtx;
     m_Eye = *pLoc;
     m_ViewDir = *pDir;
-    _prevWorldMtxPtr_Soft = NULL;   //reset so the world matrix applies the proper transform.
+    _prevWorldMtxPtr_Soft = nullptr;   //reset so the world matrix applies the proper transform.
 
     m_ViewProj = m_ProjMtx.MatMul( m_ViewMtx );
     m_nMatrixViewKey++;
@@ -706,7 +706,7 @@ void Driver3D_Soft::SetColor(Vector4 *pColor)
 {
 }
 
-TextureHandle Driver3D_Soft::CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat/*=TEX_FORMAT_RGBA8*/, uint8_t *pData/*=NULL*/, bool bGenMips/*=false*/, int32_t nFrameCnt/*=1*/)
+TextureHandle Driver3D_Soft::CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat/*=TEX_FORMAT_RGBA8*/, uint8_t *pData/*=nullptr*/, bool bGenMips/*=false*/, int32_t nFrameCnt/*=1*/)
 {
     Texture *pTex = new Texture();
 
@@ -718,7 +718,7 @@ TextureHandle Driver3D_Soft::CreateTexture(uint32_t uWidth, uint32_t uHeight, ui
     assert( nFrameCnt < 32 );
     for (int32_t f=0; f<32; f++)
     {
-        pTex->m_pData[f] = NULL;
+        pTex->m_pData[f] = nullptr;
     }
 
     int32_t nBytesPerPixel = (uFormat!=TEX_FORMAT_FORCE_32bpp) ? (m_nBitDepth>>3) : 4;
@@ -969,7 +969,7 @@ uint32_t Driver3D_Soft::CreateIB()
     IBO *ibo    = new IBO;
     uint32_t uIBO_ID = (uint32_t)m_IBO.size();
     ibo->uFlags = 0;
-    ibo->pRendererData = NULL;
+    ibo->pRendererData = nullptr;
     m_IBO.push_back(ibo);
 
     return uIBO_ID;
@@ -997,8 +997,8 @@ void Driver3D_Soft::ResetIBFlags(uint32_t uID)
 void Driver3D_Soft::ClearDrawData()
 {
     _trianglesPerFrame = 0;
-    m_pCurVBO = NULL;
-    m_pCurPolygonData = NULL;
+    m_pCurVBO = nullptr;
+    m_pCurPolygonData = nullptr;
     m_uBlendMode = BLEND_NONE;
     m_bAlphaTest = false;
 }
@@ -1089,7 +1089,7 @@ void Driver3D_Soft::WorldToClip(VBO *pVBO)
 //The function assumes a vertex buffer has already been set.
 void Driver3D_Soft::RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex/*=0*/)
 {
-    if ( m_pCurVBO == NULL )
+    if ( m_pCurVBO == nullptr )
         return;
 
     uint32_t uIB_ID = pIB->GetID();
@@ -1147,7 +1147,7 @@ void Driver3D_Soft::RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, in
     }
 #endif
 
-    PolygonData *polyData = NULL;//(PolygonData *)pIbo->pRendererData;
+    PolygonData *polyData = nullptr;//(PolygonData *)pIbo->pRendererData;
     for (int t=0, i=startIndex; t<nTriCnt; t++, i+=3)
     {
         //EXT_TEXTURE_INDEX
@@ -1159,7 +1159,7 @@ void Driver3D_Soft::RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, in
             DrawScanline::_texFlip = m_pTexIndex[t>>1]>>8;
         }
 
-        TriangleRasterizer::DrawClippedNGon_Indexed(this, m_pCurVBO, 3, &pIndices[i], s_uColormapID == 0 ? true : false, alphaMode, NULL);//polyData?&polyData[t]:NULL);
+        TriangleRasterizer::DrawClippedNGon_Indexed(this, m_pCurVBO, 3, &pIndices[i], s_uColormapID == 0 ? true : false, alphaMode, nullptr);//polyData?&polyData[t]:nullptr);
     }
 
     _trianglesPerFrame += nTriCnt;

--- a/render/FontManager.cpp
+++ b/render/FontManager.cpp
@@ -22,7 +22,7 @@ bool FontManager::Init(const std::string& szFontPath, IDriver3D *pDriver)
     m_pDriver  = pDriver;
     m_FontPath = szFontPath;
 
-    if ( m_pDriver == NULL )
+    if ( m_pDriver == nullptr )
         return false;
 
     m_pVB = xlNew VertexBuffer(pDriver);
@@ -84,12 +84,12 @@ void FontManager::Destroy()
     if ( m_pVB )
     {
         xlDelete m_pVB;
-        m_pVB = NULL;
+        m_pVB = nullptr;
     }
     if ( m_pIB )
     {
         xlDelete m_pIB;
-        m_pIB = NULL;
+        m_pIB = nullptr;
     }
 }
 
@@ -118,7 +118,7 @@ XLFont *FontManager::LoadFont(const std::string& szFile)
         return pFont;
     }
     TextureCache::RestorePath();
-    return NULL;
+    return nullptr;
 }
 
 void FontManager::BeginTextRendering()

--- a/render/IDriver3D.cpp
+++ b/render/IDriver3D.cpp
@@ -8,7 +8,7 @@ float LightObject::s_fAnimOffset1 = 0.0f;
 
 IDriver3D::IDriver3D()
 {
-    m_Platform    = NULL;
+    m_Platform    = nullptr;
     m_uPaletteID  = 0;
     m_uColormapID = 0;
     m_nLightCnt   = 0;
@@ -28,7 +28,7 @@ IDriver3D::~IDriver3D()
     if ( m_Platform )
     {
         xlDelete m_Platform;
-        m_Platform = NULL;
+        m_Platform = nullptr;
     }
 }
 

--- a/render/ImageLoader.cpp
+++ b/render/ImageLoader.cpp
@@ -28,12 +28,12 @@ ImageLoader::~ImageLoader(void)
     if ( m_pImageData )
     {
         xlFree(m_pImageData);
-        m_pImageData = NULL;
+        m_pImageData = nullptr;
     }
     if ( m_pImageData_Work )
     {
         xlFree(m_pImageData_Work);
-        m_pImageData_Work = NULL;
+        m_pImageData_Work = nullptr;
     }
 }
 

--- a/render/IndexBuffer.cpp
+++ b/render/IndexBuffer.cpp
@@ -10,7 +10,7 @@ IndexBuffer::IndexBuffer(IDriver3D *pDriver)
     m_uSize = 0;
     m_uIBO_ID = 0xffffffff;
     m_bLocked = false;
-    m_pMemory = NULL;
+    m_pMemory = nullptr;
     m_pDriver = pDriver;
 }
 
@@ -19,7 +19,7 @@ IndexBuffer::~IndexBuffer(void)
     if ( m_pMemory )
     {
         xlFree(m_pMemory);
-        m_pMemory = NULL;
+        m_pMemory = nullptr;
     }
     if ( m_uIBO_ID != 0xffffffff )
     {
@@ -34,7 +34,7 @@ bool IndexBuffer::Create(uint32_t uCount, uint32_t uStride, bool bDynamic)
 
     bool bSuccess = true;
     m_pMemory = (uint32_t *)xlMalloc( m_uStride * uCount );
-    if ( m_pMemory == NULL )
+    if ( m_pMemory == nullptr )
         bSuccess = false;
 
     m_uCount = uCount;
@@ -55,7 +55,7 @@ void IndexBuffer::Destroy()
     if ( m_pMemory )
     {
         xlFree(m_pMemory);
-        m_pMemory = NULL;
+        m_pMemory = nullptr;
     }
     if ( m_uIBO_ID != 0xffffffff )
     {
@@ -77,7 +77,7 @@ void IndexBuffer::Fill(uint32_t *pData)
 
 uint32_t *IndexBuffer::Lock()
 {
-    uint32_t *pRet = NULL;
+    uint32_t *pRet = nullptr;
     assert( m_bLocked == false );
     if ( m_bLocked == false )
     {

--- a/render/Mesh.cpp
+++ b/render/Mesh.cpp
@@ -10,9 +10,9 @@
 
 Mesh::Mesh()
 {
-    m_pVB = NULL;
-    m_pIB = NULL;
-    m_pMaterials = NULL;
+    m_pVB = nullptr;
+    m_pIB = nullptr;
+    m_pMaterials = nullptr;
     m_nMtlCnt = 0;
     m_bLoaded = false;
 }

--- a/render/MeshCache.cpp
+++ b/render/MeshCache.cpp
@@ -34,7 +34,7 @@ void MeshCache::Destroy()
 
 Mesh *MeshCache::GetMesh(const std::string& sName)
 {
-    Mesh *pMesh = NULL;
+    Mesh *pMesh = nullptr;
     MeshMap::iterator iMesh = m_MeshMap.find(sName);
     if ( iMesh != m_MeshMap.end() )
     {
@@ -51,7 +51,7 @@ Mesh *MeshCache::GetMesh(const std::string& sName)
 
 MeshCollision *MeshCache::GetMeshCollision(const std::string& sName)
 {
-    MeshCollision *pMeshCollision = NULL;
+    MeshCollision *pMeshCollision = nullptr;
     MeshCollisionMap::iterator iMeshCol = m_MeshCollisionMap.find(sName);
     if ( iMeshCol != m_MeshCollisionMap.end() )
     {

--- a/render/RenderQue.cpp
+++ b/render/RenderQue.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 
 IDriver3D *RenderQue::m_pDriver;
-RenderQuad *RenderQue::m_pQuads=NULL;
+RenderQuad *RenderQue::m_pQuads=nullptr;
 uint32_t RenderQue::m_uQuadCnt;
 
 std::vector<MaterialEntry *> RenderQue::m_apRenderBuckets[RBUCKET_COUNT];
@@ -38,7 +38,7 @@ void RenderQue::Destroy()
     {
         xlDelete [] m_pQuads;
     }
-    m_pQuads = NULL;
+    m_pQuads = nullptr;
 
     m_RenderEntryPool.clear();
 }
@@ -55,7 +55,7 @@ void RenderQue::Reset()
 
 RenderQuad *RenderQue::GetRenderQuad()
 {
-    RenderQuad *pQuad = NULL;
+    RenderQuad *pQuad = nullptr;
     if ( m_uQuadCnt < MAX_QUADS )
     {
         pQuad = &m_pQuads[m_uQuadCnt];
@@ -85,7 +85,7 @@ void RenderQue::AddQuad(TextureHandle hTex, Vector3 *posList, Vector2 *uvList, c
 
 MaterialEntry *RenderQue::GetEntry(RenderBuckets bucket)
 {
-    MaterialEntry *pEntry=NULL;
+    MaterialEntry *pEntry=nullptr;
     if ( m_uRenderEntryLoc < m_RenderEntryPool.size() )
     {
         pEntry = &m_RenderEntryPool[ m_uRenderEntryLoc ];
@@ -128,7 +128,7 @@ void RenderQue::Render()
         m_pDriver->EnableAlphaTest(false);
         m_pDriver->SetColor();
         m_pDriver->EnableCulling(true);
-        m_pDriver->SetWorldMatrix(NULL, 0, 0);
+        m_pDriver->SetWorldMatrix(nullptr, 0, 0);
         //go through the list.
         std::vector<MaterialEntry *>::iterator iEntry = m_apRenderBuckets[RBUCKET_OPAQUE].begin();
         std::vector<MaterialEntry *>::iterator eEntry = m_apRenderBuckets[RBUCKET_OPAQUE].end();
@@ -183,7 +183,7 @@ void RenderQue::Render()
         //Render
         m_pDriver->RenderWorldQuad(m_pQuads[q].posList, m_pQuads[q].uvList, m_pQuads[q].color, m_pQuads[q].bApplyLighting);
     }
-    m_pDriver->SetLights(0, NULL);
+    m_pDriver->SetLights(0, nullptr);
 
     //Cleanup.
     m_pDriver->SetBlendMode();

--- a/render/TextureCache.cpp
+++ b/render/TextureCache.cpp
@@ -22,7 +22,7 @@ uint32_t TextureCache::m_uPrevTexWidth = 0;
 uint32_t TextureCache::m_uPrevTexHeight= 0;
 float TextureCache::m_fRelSizeX     = 1.0f;
 float TextureCache::m_fRelSizeY   = 1.0f;
-void *TextureCache::m_pPrevExtraData = NULL;
+void *TextureCache::m_pPrevExtraData = nullptr;
 std::string TextureCache::m_SavedPath;
 
 bool TextureCache::Init(IDriver3D *pDriver)
@@ -31,7 +31,7 @@ bool TextureCache::Init(IDriver3D *pDriver)
     m_pLoader = xlNew ImageLoader();
     m_SavedPath = "";
 
-    if ( m_pLoader == NULL || m_pDriver == NULL )
+    if ( m_pLoader == nullptr || m_pDriver == nullptr )
         return false;
 
     return true;
@@ -42,7 +42,7 @@ void TextureCache::Destroy()
     if ( m_pLoader )
     {
         xlDelete m_pLoader;
-        m_pLoader = NULL;
+        m_pLoader = nullptr;
     }
     m_TextureMap.clear();
 }
@@ -102,7 +102,7 @@ TextureHandle TextureCache::LoadTexture(const std::string& szFile, bool bGenMips
         tex.uHeight = uHeight;
         tex.fRelSizeX = 1.0f;
         tex.fRelSizeY = 1.0f;
-        tex.pExtraData = NULL;
+        tex.pExtraData = nullptr;
 
         uint32_t uDataSize = 0;
         void *pExtraData = TextureLoader::GetTexExtraData(uDataSize);
@@ -180,7 +180,7 @@ TextureHandle TextureCache::LoadTextureFromMem_Pal(const uint8_t *pImgBuffer, ui
         tex.uHeight = height;
         tex.fRelSizeX = 1.0f;
         tex.fRelSizeY = 1.0f;
-        tex.pExtraData = NULL;
+        tex.pExtraData = nullptr;
 
         uint32_t uDataSize = 0;
         void *pExtraData = TextureLoader::GetTexExtraData(uDataSize);
@@ -257,7 +257,7 @@ TextureHandle TextureCache::GameFile_LoadTexture_TexList(uint32_t uTextureType, 
                 tex.uHeight = uHeight;
                 tex.fRelSizeX = 1.0f;
                 tex.fRelSizeY = 1.0f;
-                tex.pExtraData = NULL;
+                tex.pExtraData = nullptr;
 
                 uint32_t uDataSize = 0;
                 void *pExtraData = TextureLoader::GetTexExtraData(uDataSize);
@@ -304,7 +304,7 @@ TextureHandle TextureCache::GameFile_LoadTexture_TexList(uint32_t uTextureType, 
             tex.uHeight = uHeight;
             tex.fRelSizeX = 1.0f;
             tex.fRelSizeY = 1.0f;
-            tex.pExtraData = NULL;
+            tex.pExtraData = nullptr;
 
             uint32_t uDataSize = 0;
             void *pExtraData = TextureLoader::GetTexExtraData(uDataSize);
@@ -378,7 +378,7 @@ TextureHandle TextureCache::GameFile_LoadTexture(uint32_t uTextureType, uint32_t
                 tex.uHeight = uHeight;
                 tex.fRelSizeX = 1.0f;
                 tex.fRelSizeY = 1.0f;
-                tex.pExtraData = NULL;
+                tex.pExtraData = nullptr;
 
                 uint32_t uDataSize = 0;
                 void *pExtraData = TextureLoader::GetTexExtraData(uDataSize);
@@ -424,7 +424,7 @@ TextureHandle TextureCache::GameFile_LoadTexture(uint32_t uTextureType, uint32_t
             tex.uHeight = uHeight;
             tex.fRelSizeX = 1.0f;
             tex.fRelSizeY = 1.0f;
-            tex.pExtraData = NULL;
+            tex.pExtraData = nullptr;
 
             uint32_t uDataSize = 0;
             void *pExtraData = TextureLoader::GetTexExtraData(uDataSize);

--- a/render/VertexBuffer.cpp
+++ b/render/VertexBuffer.cpp
@@ -11,7 +11,7 @@ VertexBuffer::VertexBuffer(IDriver3D *pDriver)
     m_uSize = 0;
     m_uVBO_ID = 0xffffffff;
     m_bLocked = false;
-    m_pMemory = NULL;
+    m_pMemory = nullptr;
 
     m_pDriver = pDriver;
 }
@@ -21,7 +21,7 @@ VertexBuffer::~VertexBuffer(void)
     if ( m_pMemory )
     {
         xlFree(m_pMemory);
-        m_pMemory = NULL;
+        m_pMemory = nullptr;
     }
     if ( m_uVBO_ID != 0xffffffff )
     {
@@ -39,7 +39,7 @@ bool VertexBuffer::Create(uint32_t uStride, uint32_t uCount, bool bDynamic, uint
 {
     bool bSuccess = true;
     m_pMemory = xlMalloc( uStride * uCount );
-    if ( m_pMemory == NULL )
+    if ( m_pMemory == nullptr )
         bSuccess = false;
 
     m_uStride = uStride;
@@ -68,7 +68,7 @@ void VertexBuffer::Destroy()
     if ( m_pMemory )
     {
         xlFree(m_pMemory);
-        m_pMemory = NULL;
+        m_pMemory = nullptr;
     }
     m_uCount = 0;
     m_uSize = 0;
@@ -85,7 +85,7 @@ void VertexBuffer::Fill(void *pData)
 
 void *VertexBuffer::Lock()
 {
-    void *pRet = NULL;
+    void *pRet = nullptr;
     assert( m_bLocked == false );
     if ( m_bLocked == false )
     {

--- a/render/triangleRasterizer/TriangleRasterizer.h
+++ b/render/triangleRasterizer/TriangleRasterizer.h
@@ -68,7 +68,7 @@ struct TriEdge
 namespace TriangleRasterizer
 {
     void BuildTables();
-    void DrawClippedNGon_Indexed(Driver3D_Soft *pDriver, VBO *pVertices, int vCnt, const uint16_t *pIdx, bool bRecLighting, int alphaMode, PolygonData *polygonData=NULL);
+    void DrawClippedNGon_Indexed(Driver3D_Soft *pDriver, VBO *pVertices, int vCnt, const uint16_t *pIdx, bool bRecLighting, int alphaMode, PolygonData *polygonData=nullptr);
     void DrawClippedNGon(Driver3D_Soft *pDriver, VBO *pVertices, int vCnt, int offs, int alphaMode);
 };
 

--- a/render/win/Driver3D_OGL_Win.cpp
+++ b/render/win/Driver3D_OGL_Win.cpp
@@ -8,7 +8,7 @@
 //WGL Extension crap... fortunately only on Windows.
 typedef BOOL (WINAPI * PFNWGLSWAPINTERVALEXTPROC)(int interval);
 typedef const char * (WINAPI * PFNWGLGETEXTENSIONSSTRINGEXTPROC)(void);
-PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT = NULL;
+PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT = nullptr;
 
 HGLRC m_hRC;
 HDC m_hDC;
@@ -20,12 +20,12 @@ WORD m_GammaRamp[3][256];
 bool _WGLExtensionSupported(const char *extension_name)
 {
     // this is pointer to function which returns pointer to string with list of all wgl extensions
-    PFNWGLGETEXTENSIONSSTRINGEXTPROC _wglGetExtensionsStringEXT = NULL;
+    PFNWGLGETEXTENSIONSSTRINGEXTPROC _wglGetExtensionsStringEXT = nullptr;
 
     // determine pointer to wglGetExtensionsStringEXT function
     _wglGetExtensionsStringEXT = (PFNWGLGETEXTENSIONSSTRINGEXTPROC)wglGetProcAddress("wglGetExtensionsStringEXT");
 
-    if (strstr(_wglGetExtensionsStringEXT(), extension_name) == NULL)
+    if (strstr(_wglGetExtensionsStringEXT(), extension_name) == nullptr)
     {
         // string was not found
         return false;
@@ -46,7 +46,7 @@ Driver3D_OGL_Win::~Driver3D_OGL_Win()
     //Restore the gamma ramp.
     if ( EngineSettings::get().IsFeatureEnabled(EngineSettings::FULLSCREEN) )
     {
-        HDC hdc = GetDC(NULL);
+        HDC hdc = GetDC(nullptr);
         SetDeviceGammaRamp(hdc, m_GammaRamp_Default);
     }
 }

--- a/scriptsystem/ScriptSystem.cpp
+++ b/scriptsystem/ScriptSystem.cpp
@@ -54,7 +54,7 @@ bool ScriptSystem::Init()
 {
     // Create the script engine
     m_Engine = asCreateScriptEngine(ANGELSCRIPT_VERSION);
-    if( m_Engine == NULL )
+    if( m_Engine == nullptr )
     {
         return false;
     }
@@ -69,7 +69,7 @@ bool ScriptSystem::Init()
     RegisterStdString(m_Engine);
     RegisterScriptArray(m_Engine, true);
 
-    m_pContext = NULL;
+    m_pContext = nullptr;
 
     memset(m_afGlobalStore, 0, sizeof(float)*32);
     memset(m_aTimers, 0, sizeof(int)*32);

--- a/scriptsystem/ScriptSystem.h
+++ b/scriptsystem/ScriptSystem.h
@@ -69,7 +69,7 @@ public:
     //Execute the current script function.
     static void ExecuteFunc();
     //Make this the current function and then execute.
-    static uint32_t ExecuteFunc(SHANDLE hFunc, int32_t nArgCnt=0, const ScriptArgument *pArgs=NULL, bool bRetValueExpected=false);
+    static uint32_t ExecuteFunc(SHANDLE hFunc, int32_t nArgCnt=0, const ScriptArgument *pArgs=nullptr, bool bRetValueExpected=false);
 
     //Global memory store that can be accessed by the scripts...
     static void SetGlobalStoreVal(int var, float val);

--- a/threading/Posix/Thread.h
+++ b/threading/Posix/Thread.h
@@ -135,16 +135,16 @@ class Thread
 
       if ( I.Flags & 1 /*CancelEnable*/ )
       {
-        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE,NULL);
+        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE,nullptr);
 
         if ( I.Flags & 2 /*CancelAsync*/ )
-          pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS,NULL);
+          pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS,nullptr);
         else
-          pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED,NULL);
+          pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED,nullptr);
       }
       else
       {
-        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE,NULL);
+        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE,nullptr);
       }
 
       if ( I.Owner )
@@ -278,16 +278,16 @@ class Thread<void>
 
       if ( I.Flags & 1 /*CancelEnable*/ )
       {
-        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE,NULL);
+        pthread_setcancelstate(PTHREAD_CANCEL_ENABLE,nullptr);
 
         if ( I.Flags & 2 /*CancelAsync*/ )
-          pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS,NULL);
+          pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS,nullptr);
         else
-          pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED,NULL);
+          pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED,nullptr);
       }
       else
       {
-        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE,NULL);
+        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE,nullptr);
       }
 
       if ( I.Owner )

--- a/threading/Win32/Thread.h
+++ b/threading/Win32/Thread.h
@@ -105,7 +105,7 @@ class Thread
     static Handle Self()
     {
       //Handle Hnd = InvalidHandle;
-      //DuplicateHandle(GetCurrentProcess(),GetCurrentThread(),GetCurrentProcess(),(LPHANDLE)&Hnd,NULL,0,NULL);
+      //DuplicateHandle(GetCurrentProcess(),GetCurrentThread(),GetCurrentProcess(),(LPHANDLE)&Hnd,nullptr,0,nullptr);
       //return Hnd;
 
       // only a pseudo-handle!

--- a/ui/Console.cpp
+++ b/ui/Console.cpp
@@ -44,10 +44,10 @@ Vector4 m_aColorTable[]=
 Console::Console(IDriver3D *pDriver)
 {
     m_pDriver = pDriver;
-    m_DefaultCommand = NULL;
+    m_DefaultCommand = nullptr;
     m_MaxCommands = 32;
     m_MaxTextLines = 256;
-    m_pFont = NULL;
+    m_pFont = nullptr;
     m_nCommandHistory = -1;
     m_nScrollOffs = 0;
     m_bActive = false;
@@ -462,7 +462,7 @@ void Console::Render()
     FontManager::EndTextRendering();
 }
 
-void Console::PrintCommands(const char *pszText/*=NULL*/)
+void Console::PrintCommands(const char *pszText/*=nullptr*/)
 {
     char szCmdText[256];
     size_t l=0;
@@ -476,7 +476,7 @@ void Console::PrintCommands(const char *pszText/*=NULL*/)
     std::list<ConsoleItem>::const_iterator iter;
     for (iter = m_ItemList.begin(); iter != m_ItemList.end(); ++iter)
     {
-        if ( pszText != NULL && l > 0 )
+        if ( pszText != nullptr && l > 0 )
         {
             if ( strnicmp(pszText, (*iter).name.c_str(), l) != 0 )
                 continue;
@@ -692,13 +692,13 @@ bool Console::ParseCommandLine()
                     return true;
                     break;
                 default:
-                    m_DefaultCommand(arguments, NULL);
+                    m_DefaultCommand(arguments, nullptr);
                     return false;
                     break;
             }
         }
     }
-    m_DefaultCommand(arguments, NULL);
+    m_DefaultCommand(arguments, nullptr);
     m_CommandLine.clear();
 
     return false;

--- a/ui/Console.h
+++ b/ui/Console.h
@@ -38,7 +38,7 @@ public:
 
     void SetGameInfo(const std::string& gameName, int32_t versionMinor, int32_t versionMajor);
 
-    void AddItem(const std::string& itemName, void *ptr, ConsoleItemType type, const std::string& itemHelp, void *pUserData=NULL);
+    void AddItem(const std::string& itemName, void *ptr, ConsoleItemType type, const std::string& itemHelp, void *pUserData=nullptr);
     void RemoveItem(const std::string& itemName);
 
     void SetDefaultCommand(ConsoleFunction func);
@@ -60,7 +60,7 @@ public:
     bool IsChatActive() { return m_bChatMode; }
     void EnableCommandEcho(bool bEnable) { m_bEchoCommands = bEnable; }
 
-    void PrintCommands(const char *pszText=NULL);
+    void PrintCommands(const char *pszText=nullptr);
     void LoadNewBackground(const char *pszBackground);
 
 private:

--- a/ui/UI_System.cpp
+++ b/ui/UI_System.cpp
@@ -40,9 +40,9 @@ IDriver3D *UI_System::m_pDriver;
 Engine *UI_System::m_pEngine;
 Vector2 UI_System::m_uvTop(0,0);
 Vector2 UI_System::m_uvBot(1,1);
-UI_RenderFrame *m_pUI_Atlas=NULL;
+UI_RenderFrame *m_pUI_Atlas=nullptr;
 
-UI_RenderFrame *UI_System::m_pRenderFramePool=NULL;
+UI_RenderFrame *UI_System::m_pRenderFramePool=nullptr;
 LFD_Anim *UI_System::m_pLFD_Anim_List[MAX_LFD_ANIM];
 
 int Editor_UI_Atlas;
@@ -68,12 +68,12 @@ bool UI_System::Init(IDriver3D *pDriver, Engine *pEngine)
 {
     m_bScriptsLoaded = false;
     m_bScriptExeSucceeded = false;
-    m_Top = NULL;
-    m_Leaf = NULL;
-    m_Context = NULL;
-    m_PendingScreenChange = NULL;
-    m_PushScreen = NULL;
-    m_PopScreen = NULL;
+    m_Top = nullptr;
+    m_Leaf = nullptr;
+    m_Context = nullptr;
+    m_PendingScreenChange = nullptr;
+    m_PushScreen = nullptr;
+    m_PopScreen = nullptr;
 
     //m_fVirt_Scr_W = 320.0f;
     //m_fVirt_Scr_H = 200.0f;
@@ -222,7 +222,7 @@ void UI_System::Update()
 
         //Enter the next screen.
         m_Top = m_PendingScreenChange;
-        m_PendingScreenChange = NULL;
+        m_PendingScreenChange = nullptr;
         assert( m_Top->m_hOnEnter );
 
         m_Context = m_Top;
@@ -235,14 +235,14 @@ void UI_System::Update()
         UI_Screen *pScreen = m_Top;
         m_Leaf->m_child = m_PushScreen;
         m_PushScreen->m_parent = m_Leaf;
-        m_PushScreen->m_child  = NULL;
+        m_PushScreen->m_child  = nullptr;
 
         assert( m_PushScreen->m_hOnEnter >= 0 );
         m_Context = m_PushScreen;
         ScriptSystem::ExecuteFunc( m_PushScreen->m_hOnEnter );
 
         m_Leaf = m_PushScreen;
-        m_PushScreen = NULL;
+        m_PushScreen = nullptr;
     }
     else if ( m_PopScreen && m_PopScreen->m_parent )
     {
@@ -250,8 +250,8 @@ void UI_System::Update()
         ScriptSystem::ExecuteFunc( m_PopScreen->m_hOnExit );
 
         m_Leaf = m_PopScreen->m_parent;
-        m_Leaf->m_child = NULL;
-        m_PopScreen = NULL;
+        m_Leaf->m_child = nullptr;
+        m_PopScreen = nullptr;
     }
     m_Context = m_Leaf;
 
@@ -367,7 +367,7 @@ void UI_System::RenderChildWindows(UI_Window *pWin, int x, int y)
 
 UI_Screen *UI_System::AddScreen(const std::string& sName)
 {
-    UI_Screen *pScreen = NULL;
+    UI_Screen *pScreen = nullptr;
     std::map<std::string, UI_Screen *>::iterator iScreen = m_ScreenMap.find(sName);
     if ( iScreen != m_ScreenMap.end() )
     {
@@ -410,10 +410,10 @@ UI_Window *UI_System::AddWindow(const std::string& sName, const std::string& sTe
     sprintf(szFuncName, "%s_OnRelease", sName.c_str());
     pWindow->m_hOnRelease = ScriptSystem::GetFunc( ScriptSystem::SCR_MODULE_UI, szFuncName );
 
-    if ( parent == NULL )
+    if ( parent == nullptr )
     {
-        pWindow->m_parent = NULL;
-        if ( m_Context->m_childWindow == NULL )
+        pWindow->m_parent = nullptr;
+        if ( m_Context->m_childWindow == nullptr )
         {
             m_Context->m_childWindow = pWindow;
         }
@@ -422,7 +422,7 @@ UI_Window *UI_System::AddWindow(const std::string& sName, const std::string& sTe
             UI_Window *curWin = m_Context->m_childWindow;
             while (1)
             {
-                if ( curWin->m_sibling == NULL )
+                if ( curWin->m_sibling == nullptr )
                 {
                     curWin->m_sibling = pWindow;
                     break;
@@ -437,7 +437,7 @@ UI_Window *UI_System::AddWindow(const std::string& sName, const std::string& sTe
     else
     {
         pWindow->m_parent = parent;
-        if ( parent->m_child == NULL )
+        if ( parent->m_child == nullptr )
         {
             parent->m_child = pWindow;
         }
@@ -446,7 +446,7 @@ UI_Window *UI_System::AddWindow(const std::string& sName, const std::string& sTe
             UI_Window *curWin = parent->m_child;
             while (1)
             {
-                if ( curWin->m_sibling == NULL )
+                if ( curWin->m_sibling == nullptr )
                 {
                     curWin->m_sibling = pWindow;
                     break;
@@ -466,7 +466,7 @@ UI_Window *UI_System::AddWindow(const std::string& sName, const std::string& sTe
 /********************************************************
  ***** UI Script Functions (called from UI scripts) *****
  ********************************************************/
-UI_Window *_pCurWindow = NULL;
+UI_Window *_pCurWindow = nullptr;
 UI_Window *_apWindowStack[16];
 int _stackPtr = 0;
 void UI_System::UI_CreateWindow(std::string& sName, std::string& sText, int type, int x, int y, int w, int h, int flags)
@@ -502,7 +502,7 @@ void UI_System::UI_PopWindow()
         else
         {
             _stackPtr   = 0;
-            _pCurWindow = NULL;
+            _pCurWindow = nullptr;
         }
     }
 }
@@ -544,8 +544,8 @@ void UI_System::UI_StartScreen(std::string& sUI_Start)
         pScreen->m_sName    = sUI_Start;
         pScreen->m_hOnEnter = hOnEnter;
         pScreen->m_uFlags   = UIFLAG_NONE;
-        pScreen->m_parent   = NULL;
-        pScreen->m_child    = NULL;
+        pScreen->m_parent   = nullptr;
+        pScreen->m_child    = nullptr;
 
         sprintf(szFuncName, "%s_OnExit", sUI_Start.c_str());
         pScreen->m_hOnExit   = ScriptSystem::GetFunc( ScriptSystem::SCR_MODULE_UI, szFuncName );
@@ -577,8 +577,8 @@ void UI_System::UI_PushScreen(const std::string& uiName, int flags, int backgrnd
         pScreen->m_sName    = uiName;
         pScreen->m_hOnEnter = hOnEnter;
         pScreen->m_uFlags   = (uint32_t)flags;
-        pScreen->m_parent   = NULL;
-        pScreen->m_child    = NULL;
+        pScreen->m_parent   = nullptr;
+        pScreen->m_child    = nullptr;
 
         sprintf(szFuncName, "%s_OnExit",   uiName.c_str());
         pScreen->m_hOnExit   = ScriptSystem::GetFunc( ScriptSystem::SCR_MODULE_UI, szFuncName );
@@ -626,13 +626,13 @@ void UI_System::FreeRenderFramePool()
     {
         xlDelete [] m_pRenderFramePool;
     }
-    m_pRenderFramePool = NULL;
+    m_pRenderFramePool = nullptr;
 }
 
 UI_RenderFrame *UI_System::AllocRenderFrame()
 {
-    if ( m_pRenderFramePool == NULL )
-        return NULL;
+    if ( m_pRenderFramePool == nullptr )
+        return nullptr;
 
     for (uint32_t i=0; i<MAX_RENDERFRAMEPOOL_SIZE; i++)
     {
@@ -642,7 +642,7 @@ UI_RenderFrame *UI_System::AllocRenderFrame()
             return &m_pRenderFramePool[i];
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 void UI_System::FreeRenderFrame(uint32_t uFrameID)
@@ -700,7 +700,7 @@ int UI_System::UI_CreateLFD_Anim(std::string& sArchive, std::string& sAnim, std:
     int32_t ID = -1;
     for (int32_t i=0; i<MAX_LFD_ANIM; i++)
     {
-        if ( m_pLFD_Anim_List[i] == NULL )
+        if ( m_pLFD_Anim_List[i] == nullptr )
         {
             ID = i;
             break;
@@ -728,7 +728,7 @@ void UI_System::UI_DestroyLFD_Anim(int ID)
     {
         xlDelete m_pLFD_Anim_List[ID];
     }
-    m_pLFD_Anim_List[ID] = NULL;
+    m_pLFD_Anim_List[ID] = nullptr;
 }
 
 void UI_System::UI_RenderLFD_Anim(int ID, int frame, int x, int y)
@@ -1094,7 +1094,7 @@ void UI_System::UI_PrintMousePos(int x, int y, int size)
 
 float UI_System::UI_GetCurrentBrightness()
 {
-    if ( m_pEngine == NULL )
+    if ( m_pEngine == nullptr )
         return 1.0f;
 
     return m_pEngine->GetCurrentBrightness();
@@ -1102,7 +1102,7 @@ float UI_System::UI_GetCurrentBrightness()
 
 float UI_System::UI_GetSpeed()
 {
-    if ( m_pEngine == NULL )
+    if ( m_pEngine == nullptr )
         return 0.0f;
 
     return m_pEngine->GetCurrentSpeed();
@@ -1200,7 +1200,7 @@ void UI_System::KeyDownCallback(int32_t key)
     if ( key == XL_F11 )
     {
         UI_Screen *pUI_Editor = FindScreen("XL_UI_Editor");
-        if ( pUI_Editor == NULL || m_Context != pUI_Editor )
+        if ( pUI_Editor == nullptr || m_Context != pUI_Editor )
         {
             UI_PushScreen( "XL_UI_Editor", UIFLAG_OVERLAY, 0);
         }
@@ -1209,7 +1209,7 @@ void UI_System::KeyDownCallback(int32_t key)
 
 UI_Screen *UI_System::FindScreen(const std::string& sName)
 {
-    UI_Screen *pScreen = NULL;
+    UI_Screen *pScreen = nullptr;
     std::map<std::string, UI_Screen *>::iterator iScreen = m_ScreenMap.find(sName);
     if ( iScreen != m_ScreenMap.end() )
     {
@@ -1229,9 +1229,9 @@ UI_Screen::UI_Screen()
     m_hOnKey    = nullptr;
 
     m_uFlags = UI_System::UIFLAG_NONE;
-    m_parent = NULL;
-    m_child  = NULL;
-    m_childWindow = NULL;
+    m_parent = nullptr;
+    m_child  = nullptr;
+    m_childWindow = nullptr;
 }
 
 UI_Screen::~UI_Screen()
@@ -1257,10 +1257,10 @@ UI_Window::UI_Window()
     m_bMoving = false;
     m_bEnabled = true;
 
-    m_parentScreen = NULL;
-    m_child        = NULL;
-    m_sibling      = NULL;
-    m_parent       = NULL;
+    m_parentScreen = nullptr;
+    m_child        = nullptr;
+    m_sibling      = nullptr;
+    m_parent       = nullptr;
 }
 
 UI_Window::~UI_Window()
@@ -1272,7 +1272,7 @@ void UI_Window::Update(bool bMouseOver, int nMouseX, int nMouseY, int x, int y)
     m_uState = UI_State_Normal;
     if ( m_hOnUpdate )   //custom script update function.
     {
-        m_uState = ScriptSystem::ExecuteFunc( m_hOnUpdate, 0, NULL, true );
+        m_uState = ScriptSystem::ExecuteFunc( m_hOnUpdate, 0, nullptr, true );
     }
     else if ( bMouseOver )
     {

--- a/ui/UI_System.h
+++ b/ui/UI_System.h
@@ -168,7 +168,7 @@ private:
 
     //Add a new screen, if it hasn't already been added.
     static UI_Screen *AddScreen(const std::string& sName);
-    static UI_Window *AddWindow(const std::string& sName, const std::string& sText, uint32_t uType, int32_t x, int32_t y, int32_t w, int32_t h, uint32_t flags, UI_Window *parent=NULL);
+    static UI_Window *AddWindow(const std::string& sName, const std::string& sText, uint32_t uType, int32_t x, int32_t y, int32_t w, int32_t h, uint32_t flags, UI_Window *parent=nullptr);
 
     //Script Functions, these are call by the UI Scripts.
     //UI_StartScreen is the first UI screen to start up, the program entry point.

--- a/ui/XL_Console.cpp
+++ b/ui/XL_Console.cpp
@@ -78,7 +78,7 @@ void XL_Console::Destroy()
 
 void XL_Console::_KeyDownCallback(int32_t key)
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return;
 
     if ( key == XL_BACK )
@@ -97,7 +97,7 @@ void XL_Console::_KeyDownCallback(int32_t key)
 
 void XL_Console::_CharDownCallback(int32_t key)
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return;
 
     s_pConsole->PassKey((char)key);
@@ -105,7 +105,7 @@ void XL_Console::_CharDownCallback(int32_t key)
 
 void XL_Console::Render()
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return;
 
     s_pConsole->Render();
@@ -118,7 +118,7 @@ void XL_Console::RegisterCmd(const std::string& itemName, void *ptr, Console::Co
 
 bool XL_Console::IsActive()
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return false;
 
     return s_pConsole->IsActive();
@@ -126,7 +126,7 @@ bool XL_Console::IsActive()
 
 bool XL_Console::IsChatActive()
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return false;
 
     return s_pConsole->IsChatActive();
@@ -134,7 +134,7 @@ bool XL_Console::IsChatActive()
 
 bool XL_Console::IsPaused()
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return false;
 
     return s_pConsole->IsPaused();
@@ -142,7 +142,7 @@ bool XL_Console::IsPaused()
 
 void XL_Console::Print(const std::string& szMsg)
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return;
 
     s_pConsole->Print(szMsg);
@@ -150,7 +150,7 @@ void XL_Console::Print(const std::string& szMsg)
 
 void XL_Console::PrintF(const char *pszString, ...)
 {
-    if ( s_pConsole == NULL )
+    if ( s_pConsole == nullptr )
         return;
 
     va_list args;

--- a/win/main.cpp
+++ b/win/main.cpp
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
     // Main message loop:
     while (true)
     {
-        if ( PeekMessage(&msg, NULL, 0, 0, PM_REMOVE) )
+        if ( PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE) )
         {
             if ( msg.message == WM_QUIT )
                 break;
@@ -298,7 +298,7 @@ int main(int argc, char *argv[])
     if ( m_pEngine )
     {
         xlDelete m_pEngine;
-        m_pEngine = NULL;
+        m_pEngine = nullptr;
     }
 
     if ( settings.IsServer() )
@@ -334,7 +334,7 @@ ATOM MyRegisterClass(HINSTANCE hInstance)
     wcex.cbWndExtra     = 0;
     wcex.hInstance      = hInstance;
     wcex.hIcon          = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_XLENGINE));
-    wcex.hCursor        = LoadCursor(NULL, IDC_ARROW);
+    wcex.hCursor        = LoadCursor(nullptr, IDC_ARROW);
     wcex.hbrBackground  = 0;
     wcex.lpszMenuName   = 0;
     wcex.lpszClassName  = szWindowClass;
@@ -376,14 +376,14 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow, int w, int h)
         if (ChangeDisplaySettings(&dmScreenSettings, CDS_FULLSCREEN)!=DISP_CHANGE_SUCCESSFUL)
         {
             // If The Mode Fails, Offer Two Options.  Quit Or Use Windowed Mode.
-            if ( MessageBox(NULL,"The Requested Fullscreen Mode Is Not Supported By\nYour Video Card. Use Windowed Mode Instead?", "XL Engine", MB_YESNO|MB_ICONEXCLAMATION) == IDYES )
+            if ( MessageBox(nullptr,"The Requested Fullscreen Mode Is Not Supported By\nYour Video Card. Use Windowed Mode Instead?", "XL Engine", MB_YESNO|MB_ICONEXCLAMATION) == IDYES )
             {
                 g_bFullScreen = false;      // Windowed Mode Selected.  Fullscreen = FALSE
             }
             else
             {
                 // Pop Up A Message Box Letting User Know The Program Is Closing.
-                MessageBox(NULL,"Program Will Now Close.", "ERROR", MB_OK|MB_ICONSTOP);
+                MessageBox(nullptr,"Program Will Now Close.", "ERROR", MB_OK|MB_ICONSTOP);
                 return FALSE;                                   // Return FALSE
             }
         }
@@ -408,7 +408,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow, int w, int h)
         desiredSize.bottom = h;
         AdjustWindowRect(&desiredSize, dwStyle, FALSE);
 
-        hWnd = CreateWindow(szWindowClass, szTitle, dwStyle, CW_USEDEFAULT, 0, desiredSize.right-desiredSize.left, desiredSize.bottom-desiredSize.top, NULL, NULL, hInstance, NULL);
+        hWnd = CreateWindow(szWindowClass, szTitle, dwStyle, CW_USEDEFAULT, 0, desiredSize.right-desiredSize.left, desiredSize.bottom-desiredSize.top, nullptr, nullptr, hInstance, nullptr);
     }
     else
     {
@@ -416,7 +416,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow, int w, int h)
         DWORD dwStyle=WS_POPUP | WS_CLIPSIBLINGS | WS_CLIPCHILDREN; // Windows Style
         ShowCursor(FALSE);
 
-        hWnd = CreateWindowEx(dwExStyle, szWindowClass, szTitle, dwStyle, 0, 0, w, h, NULL, NULL, hInstance, NULL);
+        hWnd = CreateWindowEx(dwExStyle, szWindowClass, szTitle, dwStyle, 0, 0, w, h, nullptr, nullptr, hInstance, nullptr);
     }
 
     if (!hWnd)

--- a/world/LevelFunc.cpp
+++ b/world/LevelFunc.cpp
@@ -21,8 +21,8 @@ LevelFunc::LevelFunc(WorldCell *pWorldCell, int32_t nSector, int32_t nWall)
     m_nWall = nWall;
     m_pWorldCell = pWorldCell;
 
-    m_ActivateCB = NULL;
-    m_SetValueCB = NULL;
+    m_ActivateCB = nullptr;
+    m_SetValueCB = nullptr;
 }
 
 LevelFunc::~LevelFunc()

--- a/world/LevelFunc_Default.cpp
+++ b/world/LevelFunc_Default.cpp
@@ -295,12 +295,12 @@ void LFunc_TriggerToggle_Activate(LevelFunc *pFunc, int32_t mask, int32_t items,
 //Global setup.
 void SetupDefaultLevelFuncs()
 {
-    LevelFuncMgr::AddLevelFuncCB("SlidingDoor", NULL, LFunc_SlidingDoor_SetValue);
-    LevelFuncMgr::AddLevelFuncCB("Slide", NULL, LFunc_Slide_SetValue);
-    LevelFuncMgr::AddLevelFuncCB("Elevator_MoveFloor", NULL, LFunc_Elevator_MoveFloor_SetValue);
-    LevelFuncMgr::AddLevelFuncCB("Elevator_MoveCeil", NULL, LFunc_Elevator_MoveCeil_SetValue);
-    LevelFuncMgr::AddLevelFuncCB("Rotate", NULL, LFunc_Rotate_SetValue);
-    LevelFuncMgr::AddLevelFuncCB("LightFX", NULL, LFunc_LightFX_SetValue);
-    LevelFuncMgr::AddLevelFuncCB("MotionFX", NULL, LFunc_MotionFX_SetValue);
-    LevelFuncMgr::AddLevelFuncCB("TriggerToggle", LFunc_TriggerToggle_Activate, NULL);
+    LevelFuncMgr::AddLevelFuncCB("SlidingDoor", nullptr, LFunc_SlidingDoor_SetValue);
+    LevelFuncMgr::AddLevelFuncCB("Slide", nullptr, LFunc_Slide_SetValue);
+    LevelFuncMgr::AddLevelFuncCB("Elevator_MoveFloor", nullptr, LFunc_Elevator_MoveFloor_SetValue);
+    LevelFuncMgr::AddLevelFuncCB("Elevator_MoveCeil", nullptr, LFunc_Elevator_MoveCeil_SetValue);
+    LevelFuncMgr::AddLevelFuncCB("Rotate", nullptr, LFunc_Rotate_SetValue);
+    LevelFuncMgr::AddLevelFuncCB("LightFX", nullptr, LFunc_LightFX_SetValue);
+    LevelFuncMgr::AddLevelFuncCB("MotionFX", nullptr, LFunc_MotionFX_SetValue);
+    LevelFuncMgr::AddLevelFuncCB("TriggerToggle", LFunc_TriggerToggle_Activate, nullptr);
 }

--- a/world/Logic.cpp
+++ b/world/Logic.cpp
@@ -1,7 +1,7 @@
 #include "Logic.h"
 #include "Object.h"
 
-Logic *Logic::s_pCurLogic = NULL;
+Logic *Logic::s_pCurLogic = nullptr;
 
 Logic::Logic(const std::string& sName, void *pOwner, uint32_t uType)
 {
@@ -10,13 +10,13 @@ Logic::Logic(const std::string& sName, void *pOwner, uint32_t uType)
     m_uType = uType;
     m_uMsgMask = 0;
 
-    //first initiliaze all the callbacks to NULL.
+    //first initialize all the callbacks to null.
     for (uint32_t c=0; c<LCB_COUNT; c++)
     {
         if ( m_uType == LTYPE_CODE )
-            m_Callbacks[c].codeCB = NULL;
+            m_Callbacks[c].codeCB = nullptr;
         else
-            m_Callbacks[c].scriptCB = NULL;
+            m_Callbacks[c].scriptCB = nullptr;
     }
 
     if ( m_uType == LTYPE_SCRIPT )
@@ -38,8 +38,8 @@ bool Logic::AddCallback(uint32_t uCallbackID, LogicFunction pCallback)
         //store away this as the current logic, so the logic setup knows which logic to
         //reference.
         s_pCurLogic = this;
-        m_Callbacks[ uCallbackID ].codeCB( m_pOwner, 0, 0, NULL );
-        s_pCurLogic = NULL;
+        m_Callbacks[ uCallbackID ].codeCB( m_pOwner, 0, 0, nullptr );
+        s_pCurLogic = nullptr;
     }
 
     return true;
@@ -49,7 +49,7 @@ void Logic::InitObject(Object *parent)
 {
     if ( m_uType == LTYPE_CODE && m_Callbacks[ LCB_OBJECT_SETUP ].codeCB )
     {
-        m_Callbacks[ LCB_OBJECT_SETUP ].codeCB( m_pOwner, parent->GetID(), 0, NULL );
+        m_Callbacks[ LCB_OBJECT_SETUP ].codeCB( m_pOwner, parent->GetID(), 0, nullptr );
     }
     else if ( m_uType == LTYPE_SCRIPT && m_Callbacks[ LCB_OBJECT_SETUP ].scriptCB )
     {
@@ -61,7 +61,7 @@ void Logic::Update(Object *parent)
 {
     if ( m_uType == LTYPE_CODE && m_Callbacks[ LCB_UPDATE ].codeCB )
     {
-        m_Callbacks[ LCB_UPDATE ].codeCB( m_pOwner, parent->GetID(), 0, NULL );
+        m_Callbacks[ LCB_UPDATE ].codeCB( m_pOwner, parent->GetID(), 0, nullptr );
     }
     else if ( m_uType == LTYPE_SCRIPT && m_Callbacks[ LCB_UPDATE ].scriptCB )
     {

--- a/world/LogicManager.cpp
+++ b/world/LogicManager.cpp
@@ -28,7 +28,7 @@ Logic *LogicManager::GetLogic(const std::string& sName)
         return iLogic->second;
     }
     
-    return NULL;
+    return nullptr;
 }
 
 Logic *LogicManager::CreateLogicFromCode(const std::string& sName, void *pOwner, LogicFunction *pFunc)

--- a/world/MeshCollision.cpp
+++ b/world/MeshCollision.cpp
@@ -6,10 +6,10 @@
 
 MeshCollision::MeshCollision()
 {
-    m_pWorldMtx = NULL;
+    m_pWorldMtx = nullptr;
     m_eRadius.Set(0,0,0);
     m_vOffset.Set(0,0,0);
-    m_Polygons = NULL;
+    m_Polygons = nullptr;
     m_nPolygonCount = 0;
 }
 
@@ -23,7 +23,7 @@ MeshCollision::~MeshCollision()
             xlDelete[] m_Polygons[p].pVertexES;
         }
         xlDelete [] m_Polygons;
-        m_Polygons = NULL;
+        m_Polygons = nullptr;
     }
 }
 

--- a/world/Object.cpp
+++ b/world/Object.cpp
@@ -14,9 +14,9 @@ Object::Object()
     m_uRefCnt = 0;
     m_uRenderKey = 0xffffffff;
     
-    m_pDataComp   = NULL;
-    m_pRenderComp = NULL;
-    m_pCollisionComp = NULL;
+    m_pDataComp   = nullptr;
+    m_pRenderComp = nullptr;
+    m_pCollisionComp = nullptr;
 
     m_ObjPhysicsData.m_Loc.Set(0.0f, 0.0f, 0.0f);
     m_ObjPhysicsData.m_Dir.Set(0.0f, 1.0f, 0.0f);
@@ -57,12 +57,12 @@ void Object::Reset()
         {
             xlFree(m_pDataComp);
         }
-        m_pDataComp = NULL;
+        m_pDataComp = nullptr;
     }
     if ( m_pRenderComp )
     {
         //xlDelete m_pRenderComp;
-        m_pRenderComp = NULL;
+        m_pRenderComp = nullptr;
     }
 
     m_Logics.clear();
@@ -130,7 +130,7 @@ void Object::Update()
 
 void Object::ComputeTransformedBounds()
 {
-    if ( m_pRenderComp == NULL )
+    if ( m_pRenderComp == nullptr )
         return;
 
     Vector3 vMin, vMax;

--- a/world/ObjectManager.cpp
+++ b/world/ObjectManager.cpp
@@ -54,7 +54,7 @@ void ObjectManager::Destroy()
 
 Object *ObjectManager::CreateObject(const std::string& sName)
 {
-    Object *pObj = NULL;
+    Object *pObj = nullptr;
     if ( m_FreeObjects.size() )
     {
         //if there is a free object, just use it.
@@ -91,7 +91,7 @@ Object *ObjectManager::CreateObject(const std::string& sName)
 void ObjectManager::SetRenderComponent(uint32_t uID, const char *pszComponent)
 {
     Object *pObj = GetObjectFromID(uID);
-    if ( pObj == NULL )
+    if ( pObj == nullptr )
         return;
 
     if ( stricmp(pszComponent, "Mesh") == 0 )
@@ -219,7 +219,7 @@ Object *ObjectManager::FindObject(const std::string& sName)
             return pObj;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 Object *ObjectManager::GetObjectFromID(uint32_t uID)
@@ -316,7 +316,7 @@ ObjectPhysicsData *ObjectManager::GetObjectPhysicsData(uint32_t uID)
     {
         return pObj->GetPhysicsData();
     }
-    return NULL;
+    return nullptr;
 }
 
 void *ObjectManager::GetObjectGameData(uint32_t uID)
@@ -326,7 +326,7 @@ void *ObjectManager::GetObjectGameData(uint32_t uID)
     {
         return pObj->GetGameData();
     }
-    return NULL;
+    return nullptr;
 }
 
 void ObjectManager::SetObjectGameData(uint32_t uID, void *pData)

--- a/world/Sector.cpp
+++ b/world/Sector.cpp
@@ -10,7 +10,7 @@ Sector::Sector()
     m_x = 0;
     m_y = 0;
     m_bActive = true;
-    m_pValidNodes = NULL;
+    m_pValidNodes = nullptr;
 }
 
 Sector::~Sector()

--- a/world/Sector_2_5D.cpp
+++ b/world/Sector_2_5D.cpp
@@ -84,14 +84,14 @@ Sector_2_5D::Sector_2_5D() : Sector()
 
     memset(m_szName, 0, 64);
     
-    m_pVertexBase=NULL;
-    m_pVertexCur =NULL;
+    m_pVertexBase=nullptr;
+    m_pVertexCur =nullptr;
     m_ZRangeBase.Set(0,0);
     m_ZRangeCur.Set(0,0);
     m_vAdjOffset[0].Set(0,0,0);
     m_vAdjOffset[1].Set(0,0,0);
 
-    m_Walls = NULL;
+    m_Walls = nullptr;
     m_vAdjoin[0] = SOLID_WALL;
     m_vAdjoin[1] = SOLID_WALL;
 
@@ -101,7 +101,7 @@ Sector_2_5D::Sector_2_5D() : Sector()
     m_hFloorTex = XL_INVALID_TEXTURE;
     m_hCeilTex  = XL_INVALID_TEXTURE;
 
-    m_pFunc = NULL;
+    m_pFunc = nullptr;
 
     m_aLightFX[0] = 0;
     m_aLightFX[1] = 0;
@@ -385,7 +385,7 @@ void Sector_2_5D::RenderSectors(IDriver3D *pDriver, WorldCell *pCell, Camera *pC
             {
                 VisStack *pVAdjoin = &m_visStack_VAdjoin[v];
 
-                if ( pVAdjoin->depth == NULL )
+                if ( pVAdjoin->depth == nullptr )
                     continue;
 
                 for (uint32_t x=pVAdjoin->uStartX; x<=pVAdjoin->uEndX; x++)
@@ -788,7 +788,7 @@ void Sector_2_5D::RayCastAndActivate(Vector3 *p0, Vector3 *p1, uint32_t& uSector
         p0->x = p0->x + min_u_sec*(p1->x - p0->x);
         p0->y = p0->y + min_u_sec*(p1->y - p0->y);
         p0->z = p0->z + min_u_sec*(p1->z - p0->z);
-        LevelFunc *pWallFunc = NULL;
+        LevelFunc *pWallFunc = nullptr;
         if ( nClosestWall < 0xfffe )
         {
             //Is this an adjoin?
@@ -804,7 +804,7 @@ void Sector_2_5D::RayCastAndActivate(Vector3 *p0, Vector3 *p1, uint32_t& uSector
 
                 if ( (pSec->m_uFlags&SEC_FLAGS_ALLOW_NONSOLID_ACTIVATE) || (pNext->m_uFlags&SEC_FLAGS_ALLOW_NONSOLID_ACTIVATE) )
                 {
-                    if ( pWallFunc == NULL )
+                    if ( pWallFunc == nullptr )
                     {
                         //we hit the wall in the next sector...
                         pWallFunc = pNext->m_Walls[ pSec->m_Walls[nClosestWall].m_mirror[0] ].m_pFunc;
@@ -821,7 +821,7 @@ void Sector_2_5D::RayCastAndActivate(Vector3 *p0, Vector3 *p1, uint32_t& uSector
                     RayCastAndActivate(p0, p1, uSector, Sectors);
                     return;
                 }
-                else if ( pWallFunc == NULL )
+                else if ( pWallFunc == nullptr )
                 {
                     //we hit the wall in the next sector...
                     pWallFunc = pNext->m_Walls[ pSec->m_Walls[nClosestWall].m_mirror[0] ].m_pFunc;
@@ -1130,11 +1130,11 @@ void Sector_2_5D::_DrawWall(IDriver3D *pDriver, Sector_2_5D *pCurSec, Sector_2_5
     float u1 = uv0.x * (1.0f - t1) + uv1.x * t1;
     uv0.x = u0; uv1.x = u1;
 
-    if ( pNextSec == NULL || (pCurSec->m_Walls[w].m_flags&Wall::WALL_FLAGS_MASKWALL) )
+    if ( pNextSec == nullptr || (pCurSec->m_Walls[w].m_flags&Wall::WALL_FLAGS_MASKWALL) )
     {
         Vector3 posList[4];
         Vector2 uvList[4];
-        if ( pNextSec == NULL )
+        if ( pNextSec == nullptr )
         {
             posList[0].Set(worldPos[0].x, worldPos[0].y, pCurSec->GetZ_Floor(worldPos[0].x, worldPos[0].y, Sectors));
             posList[1].Set(worldPos[1].x, worldPos[1].y, pCurSec->GetZ_Floor(worldPos[1].x, worldPos[1].y, Sectors));
@@ -1606,7 +1606,7 @@ void Sector_2_5D::WallRasterizer(const Vector3& cPos, uint32_t uStartX, uint32_t
     int32_t x0=uStartX;
     uint16_t id = idBuffer[uStartX];
     uint16_t sec = sBuffer[uStartX];
-    Sector_2_5D *pNextSec = NULL;
+    Sector_2_5D *pNextSec = nullptr;
     int32_t x=(int32_t)uStartX+1;
     for (; x<=(int32_t)uEndX; x++)
     {
@@ -1624,12 +1624,12 @@ void Sector_2_5D::WallRasterizer(const Vector3& cPos, uint32_t uStartX, uint32_t
                 m_Camera2D.InverseTransformPointsSS_2D((float)(x1+0.5f)/fbwidth * 2.0f - 1.0f, z1, worldPos[1]);
 
                 //draw the wall
-                pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? NULL : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
+                pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? nullptr : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
 
                 //add the next buffer.
                 //now make sure that the wall opening is visible...
                 if ( pNextSec && pNextSec->m_ZRangeCur.y <= pNextSec->m_ZRangeCur.x )
-                    pNextSec = NULL;
+                    pNextSec = nullptr;
                 if ( pNextSec && x1-x0 > 1 )
                 {
                     VisStack_Push(worldPos[0], worldPos[1], x0, x1, pNextSec);
@@ -1651,12 +1651,12 @@ void Sector_2_5D::WallRasterizer(const Vector3& cPos, uint32_t uStartX, uint32_t
         m_Camera2D.InverseTransformPointsSS_2D((float)(x1+0.5f)/fbwidth * 2.0f - 1.0f, fDepth[x1], worldPos[1]);
 
         //draw the wall
-        pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? NULL : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
+        pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? nullptr : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
 
         //add the next buffer.
         //now make sure that the wall opening is visible...
         if ( pNextSec && pNextSec->m_ZRangeCur.y <= pNextSec->m_ZRangeCur.x )
-            pNextSec = NULL;
+            pNextSec = nullptr;
         if ( pNextSec && x1-x0 > 1 )
         {
             VisStack_Push(worldPos[0], worldPos[1], x0, x1, pNextSec);
@@ -1902,10 +1902,10 @@ void Sector_2_5D::Visibility2D(const Vector3& cPos, Vector2 fL, Vector2 fR, uint
     int32_t x0=uStartX;
     uint16_t id = idBuffer[uStartX];
     uint16_t sec = sBuffer[uStartX];
-    Sector_2_5D *pNextSec = NULL;
+    Sector_2_5D *pNextSec = nullptr;
     int32_t x=(int32_t)uStartX+1;
-    Sector_2_5D *pBotSec = pCurSec->m_vAdjoin[0] == 0xffff ? NULL : (Sector_2_5D *)Sectors[pCurSec->m_vAdjoin[0]];
-    Sector_2_5D *pTopSec = pCurSec->m_vAdjoin[1] == 0xffff ? NULL : (Sector_2_5D *)Sectors[pCurSec->m_vAdjoin[1]];
+    Sector_2_5D *pBotSec = pCurSec->m_vAdjoin[0] == 0xffff ? nullptr : (Sector_2_5D *)Sectors[pCurSec->m_vAdjoin[0]];
+    Sector_2_5D *pTopSec = pCurSec->m_vAdjoin[1] == 0xffff ? nullptr : (Sector_2_5D *)Sectors[pCurSec->m_vAdjoin[1]];
     for (; x<=(int32_t)uEndX; x++)
     {
         if ( idBuffer[x] != id || sBuffer[x] != sec )
@@ -1919,7 +1919,7 @@ void Sector_2_5D::Visibility2D(const Vector3& cPos, Vector2 fL, Vector2 fR, uint
                 m_Camera2D.InverseTransformPointsSS_2D((float)(x1+0.5f)/fbwidth * 2.0f - 1.0f, fDepth[x1], worldPos[1]);
 
                 //draw the wall
-                pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? NULL : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
+                pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? nullptr : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
                 _DrawWall(pDriver, pCurSec, pNextSec, pBotSec, pTopSec, id, worldPos, Sectors);
 
                 //draw the floor
@@ -1928,7 +1928,7 @@ void Sector_2_5D::Visibility2D(const Vector3& cPos, Vector2 fL, Vector2 fR, uint
                 //add the next buffer.
                 //now make sure that the wall opening is visible...
                 if ( pNextSec && pNextSec->m_ZRangeCur.y <= pNextSec->m_ZRangeCur.x )
-                    pNextSec = NULL;
+                    pNextSec = nullptr;
                 if ( pNextSec && x1-x0 > 1 )
                 {
                     VisStack_Push(worldPos[0], worldPos[1], x0, x1, pNextSec);
@@ -1976,7 +1976,7 @@ void Sector_2_5D::Visibility2D(const Vector3& cPos, Vector2 fL, Vector2 fR, uint
         m_Camera2D.InverseTransformPointsSS_2D((float)(x1+0.5f)/fbwidth * 2.0f - 1.0f, fDepth[x1], worldPos[1]);
 
         //draw the wall
-        pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? NULL : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
+        pNextSec = pCurSec->m_Walls[id].m_adjoin[0] == 0xffff ? nullptr : (Sector_2_5D *)Sectors[pCurSec->m_Walls[id].m_adjoin[0]];
         _DrawWall(pDriver, pCurSec, pNextSec, pBotSec, pTopSec, id, worldPos, Sectors);
 
         //draw the floor
@@ -1985,7 +1985,7 @@ void Sector_2_5D::Visibility2D(const Vector3& cPos, Vector2 fL, Vector2 fR, uint
         //add the next buffer.
         //now make sure that the wall opening is visible...
         if ( pNextSec && pNextSec->m_ZRangeCur.y <= pNextSec->m_ZRangeCur.x )
-            pNextSec = NULL;
+            pNextSec = nullptr;
         if ( pNextSec && x1-x0 > 1 )
         {
             VisStack_Push(worldPos[0], worldPos[1], x0, x1, pNextSec);

--- a/world/Terrain.cpp
+++ b/world/Terrain.cpp
@@ -137,17 +137,17 @@ Terrain::Terrain(IDriver3D *pDriver, World *pWorld)
     m_nHeight = 0;
     m_x = -1;
     m_y = -1;
-    m_afHeightmap = NULL;
-    m_pClimate    = NULL;
-    m_afCoastalDist = NULL;
-    m_pSector = NULL;
-    m_pWorldCell = NULL;
+    m_afHeightmap = nullptr;
+    m_pClimate    = nullptr;
+    m_afCoastalDist = nullptr;
+    m_pSector = nullptr;
+    m_pWorldCell = nullptr;
 
     for (uint32_t l=0; l<LOD_COUNT; l++)
     {
-        m_LOD[l].m_pVB       = NULL;
-        for (int i=0; i<CHUNK_COUNT; i++) m_LOD[l].m_aChunks[i].m_pChunkIB  = NULL;
-        m_LOD[l].m_pGlobalIB = NULL;
+        m_LOD[l].m_pVB       = nullptr;
+        for (int i=0; i<CHUNK_COUNT; i++) m_LOD[l].m_aChunks[i].m_pChunkIB  = nullptr;
+        m_LOD[l].m_pGlobalIB = nullptr;
 
         m_LOD[l].m_pLocalHM = xlNew float[(CHUNK_TILE_WIDTH*TILE_QUAD_WIDTH+1) * (CHUNK_TILE_WIDTH*TILE_QUAD_WIDTH+1)];
         m_LOD[l].m_pLocalNM = xlNew Vector3[(CHUNK_TILE_WIDTH*TILE_QUAD_WIDTH+1) * (CHUNK_TILE_WIDTH*TILE_QUAD_WIDTH+1)];
@@ -966,7 +966,7 @@ void Terrain::Render(Camera *pCamera)
         m_pDriver->ForceMipmapping(true);
 
         int32_t bEnable = 1;
-        m_pDriver->SetExtension_Data( IDriver3D::EXT_GOURAUD, &bEnable, NULL);
+        m_pDriver->SetExtension_Data( IDriver3D::EXT_GOURAUD, &bEnable, nullptr);
 
         //m_fZRange = 8000.0f * 4.0f;
         //m_pDriver->EnableFog(true, 8000.0f * 4.0f);
@@ -982,7 +982,7 @@ void Terrain::Render(Camera *pCamera)
         //pCamera->SetMaxRenderDistance( 400.0f );
         m_pDriver->EnableFog(true, 400.0f);
         bEnable = 0;
-        m_pDriver->SetExtension_Data( IDriver3D::EXT_GOURAUD, &bEnable, NULL);
+        m_pDriver->SetExtension_Data( IDriver3D::EXT_GOURAUD, &bEnable, nullptr);
 
         m_pDriver->ForceMipmapping(false);
     }
@@ -1121,7 +1121,7 @@ void Terrain::RenderLOD(Camera *pCamera, int32_t lod)
         }
     }
 
-    m_pDriver->SetExtension_Data(IDriver3D::EXT_TEXTURE_INDEX, NULL, NULL);
+    m_pDriver->SetExtension_Data(IDriver3D::EXT_TEXTURE_INDEX, nullptr, nullptr);
 }
 
 void Terrain::RenderChunk(Camera *pCamera, int32_t lod, int32_t chunkNum)
@@ -1348,7 +1348,7 @@ int32_t Terrain::GetSkyIndex(int x, int y)
     return m_anMapSky[idx];
 }
 
-int32_t Terrain::GetClimate(int x, int y, int *pnFlat/*=NULL*/)
+int32_t Terrain::GetClimate(int x, int y, int *pnFlat/*=nullptr*/)
 {
     int xp = x + ((m_x-7)<<4);
     int yp = y + ((m_y-7)<<4);
@@ -1656,9 +1656,9 @@ void Terrain::BuildHeightmap(int32_t newX, int32_t newY, int32_t prevX, int32_t 
     Vector3 pos = c_startPos;
 
     //first copy the part of the heightmap that stays the same but moves.
-    static float *pTmpBuffer = NULL;
-    static Vector3 *pTmpV3Buffer = NULL;
-    static float *pTmpFltBuffer = NULL;
+    static float *pTmpBuffer = nullptr;
+    static Vector3 *pTmpV3Buffer = nullptr;
+    static float *pTmpFltBuffer = nullptr;
     int32_t bufferSize = (CHUNK_TILE_WIDTH*TILE_QUAD_WIDTH+1) * (CHUNK_TILE_WIDTH*TILE_QUAD_WIDTH+1);
     if ( !pTmpBuffer )
     {

--- a/world/Terrain.h
+++ b/world/Terrain.h
@@ -56,7 +56,7 @@ public:
     bool IsActive() { return m_bActive; }
 
     //Update the terrain mesh and texturing based on the world position.
-    bool Update(int32_t x, int32_t y, int32_t nRectCnt=0, LocationRect *pRects=NULL);
+    bool Update(int32_t x, int32_t y, int32_t nRectCnt=0, LocationRect *pRects=nullptr);
 
     //Render the terrain.
     void Render(Camera *pCamera);
@@ -94,7 +94,7 @@ private:
     float SampleBaseHeightmap(int lod, int x, int y);
     float SampleCoastalDistance(int x, int y);
     void ComputeNormal(int32_t x, int32_t y);
-    int32_t GetClimate(int x, int y, int *pnFlat=NULL);
+    int32_t GetClimate(int x, int y, int *pnFlat=nullptr);
     int32_t GetSkyIndex(int x, int y);
 
     void RenderSky(int32_t skyIndex, int32_t timeIndex, Camera *pCamera);
@@ -163,7 +163,7 @@ private:
     inline Location_Daggerfall *FindLocation(int32_t x, int32_t y)
     {
         LocationMap::iterator iLoc = m_LocationMap.find( LOC_KEY(x, y) );
-        Location_Daggerfall *pLoc = NULL;
+        Location_Daggerfall *pLoc = nullptr;
         if ( iLoc != m_LocationMap.end() )
         {
             pLoc = iLoc->second;

--- a/world/World.cpp
+++ b/world/World.cpp
@@ -14,12 +14,12 @@
 
 World::World()
 {
-    m_Player   = NULL;
-    m_pCamera  = NULL;
-    m_pTerrain = NULL;
+    m_Player   = nullptr;
+    m_pCamera  = nullptr;
+    m_pTerrain = nullptr;
 
     XL_Console::RegisterCmd("r_lockcam", (void*)CC_LockCamera, Console::CTYPE_FUNCTION, "Lock the camera so that the visibility stops updating.", this);
-    XL_Console::RegisterCmd("r_maxRecursion", &Sector::s_MaxSecDrawCnt, Console::CTYPE_UINT, "Maximum portal recursion, 0 = default.", NULL);
+    XL_Console::RegisterCmd("r_maxRecursion", &Sector::s_MaxSecDrawCnt, Console::CTYPE_UINT, "Maximum portal recursion, 0 = default.", nullptr);
 
     m_uSectorTypeVis = SECTOR_TYPE_EXTERIOR;
     //m_uSectorTypeVis = SECTOR_TYPE_DUNGEON;
@@ -185,7 +185,7 @@ bool World::Raycast(Vector3 *p0, Vector3 *p1, Vector3 *pInter)
 
 WorldCell *World::GetCameraWorldCell()
 {
-    WorldCell *pCell = NULL;
+    WorldCell *pCell = nullptr;
     if ( m_pCamera )
     {
         pCell = WorldMap::GetWorldCell( m_pCamera->GetWorldPosX()>>3, m_pCamera->GetWorldPosY()>>3 );

--- a/world/WorldCell.cpp
+++ b/world/WorldCell.cpp
@@ -266,8 +266,8 @@ void WorldCell::RayCastAndActivate(Vector3 *p0, Vector3 *p1, uint32_t& uSector, 
         raycastPacket.bFoundIntersection = false;
         raycastPacket.bounds[0].Set( Math::Min(p0->x, p1->x), Math::Min(p0->y, p1->y), Math::Min(p0->z, p1->z) );
         raycastPacket.bounds[1].Set( Math::Max(p0->x, p1->x), Math::Max(p0->y, p1->y), Math::Max(p0->z, p1->z) );
-        raycastPacket.pCollisionObj = NULL;
-        raycastPacket.pCollisionSector = NULL;
+        raycastPacket.pCollisionObj = nullptr;
+        raycastPacket.pCollisionSector = nullptr;
 
         for (uint32_t i=0; i<(uint32_t)m_Sectors.size(); i++)
         {
@@ -308,8 +308,8 @@ bool WorldCell::Raycast(Vector3 *p0, Vector3 *p1, Vector3 *pInter, uint32_t uSec
         raycastPacket.bFoundIntersection = false;
         raycastPacket.bounds[0].Set( Math::Min(p0->x, p1->x), Math::Min(p0->y, p1->y), Math::Min(p0->z, p1->z) );
         raycastPacket.bounds[1].Set( Math::Max(p0->x, p1->x), Math::Max(p0->y, p1->y), Math::Max(p0->z, p1->z) );
-        raycastPacket.pCollisionObj = NULL;
-        raycastPacket.pCollisionSector = NULL;
+        raycastPacket.pCollisionObj = nullptr;
+        raycastPacket.pCollisionSector = nullptr;
 
         for (uint32_t i=0; i<(uint32_t)m_Sectors.size(); i++)
         {


### PR DESCRIPTION
I changed each one individually to make sure there were no special cases, and changed NULL in comments to null instead of nullptr for readability.

No new compiler errors with these changes, which means that all uses of NULL were correct in the first place (i.e., no implicit conversions to `int`).