### PR TITLE
Change destructor iterator pairs to range-based for loops.

### DIFF
--- a/fileformats/ArchiveManager.cpp
+++ b/fileformats/ArchiveManager.cpp
@@ -35,13 +35,12 @@ void ArchiveManager::Destroy()
 {
     m_OpenArchives.clear();
 
-    std::vector<Archive *>::iterator iArchive = m_ArchiveList.begin();
-    std::vector<Archive *>::iterator eArchive = m_ArchiveList.end();
-    for (; iArchive != eArchive; ++iArchive)
+    for (Archive *archive : m_ArchiveList)
     {
-        (*iArchive)->Close();
-        xlDelete (*iArchive);
+        archive->Close();
+        xlDelete archive;
     }
+
     m_ArchiveList.clear();
     TextureLoader::Destroy();
 }

--- a/movieplayback/LFD_Film.cpp
+++ b/movieplayback/LFD_Film.cpp
@@ -81,17 +81,15 @@ void LFD_Film::Stop()
 
     if ( m_Graphics.size() > 0 )
     {
-        std::vector<Graphic *>::iterator iter = m_Graphics.begin();
-        std::vector<Graphic *>::iterator end  = m_Graphics.end();
-        for (; iter!=end; ++iter)
+        for (Graphic *graphic : m_Graphics)
         {
-            if ( *iter )
+            if (graphic != nullptr)
             {
-                Graphic *pGraphic = *iter;
-                pGraphic->pAnim->Destroy();
-                xlDelete pGraphic->pAnim;
+                graphic->pAnim->Destroy();
+                xlDelete graphic->pAnim;
             }
         }
+
         m_Graphics.clear();
     }
 

--- a/movieplayback/MovieManager.cpp
+++ b/movieplayback/MovieManager.cpp
@@ -23,12 +23,11 @@ void MovieManager::Destroy()
 {
     m_MoviePlayers.clear();
 
-    std::vector<MoviePlayer *>::iterator iMoviePlayer = m_MoviePlayerList.begin();
-    std::vector<MoviePlayer *>::iterator eMoviePlayer = m_MoviePlayerList.end();
-    for (; iMoviePlayer != eMoviePlayer; ++iMoviePlayer)
+    for (MoviePlayer *moviePlayer : m_MoviePlayerList)
     {
-        xlDelete (*iMoviePlayer);
+        xlDelete moviePlayer;
     }
+
     m_MoviePlayerList.clear();
 }
 

--- a/os/Input.cpp
+++ b/os/Input.cpp
@@ -33,20 +33,18 @@ void Input::Init()
 
 void Input::Destroy()
 {
-    std::vector<KeyDownCB_t *>::iterator iKeyCB = m_KeyDownCB.begin();
-    std::vector<KeyDownCB_t *>::iterator eKeyCB = m_KeyDownCB.end();
-    for (; iKeyCB != eKeyCB; ++iKeyCB)
+    for (KeyDownCB_t *keyCB : m_KeyDownCB)
     {
-        xlDelete (*iKeyCB);
+        xlDelete keyCB;
     }
+
     m_KeyDownCB.clear();
 
-    std::vector<KeyDownCB_t *>::iterator iCharCB = m_CharDownCB.begin();
-    std::vector<KeyDownCB_t *>::iterator eCharCB = m_CharDownCB.end();
-    for (; iCharCB != eCharCB; ++iCharCB)
+    for (KeyDownCB_t *charCB : m_CharDownCB)
     {
-        xlDelete (*iCharCB);
+        xlDelete charCB;
     }
+
     m_CharDownCB.clear();
 }
 

--- a/render/Driver3D_Soft.cpp
+++ b/render/Driver3D_Soft.cpp
@@ -109,20 +109,19 @@ Driver3D_Soft::~Driver3D_Soft()
     //delete textures.
     if ( m_Textures.size() )
     {
-        std::vector<Texture *>::iterator iTex = m_Textures.begin();
-        std::vector<Texture *>::iterator eTex = m_Textures.end();
-        for (; iTex != eTex; ++iTex)
+        for (Texture *tex : m_Textures)
         {
-            Texture *pTex = *iTex;
-            if (!pTex)
-                continue;
-
-            for (int32_t f=0; f<pTex->m_nFrameCnt; f++)
+            if (tex != nullptr)
             {
-                free( pTex->m_pData[f] );
+                for (int32_t f = 0; f < tex->m_nFrameCnt; f++)
+                {
+                    free(tex->m_pData[f]);
+                }
+
+                delete tex;
             }
-            delete pTex;
         }
+
         m_Textures.clear();
     }
 

--- a/render/FontManager.cpp
+++ b/render/FontManager.cpp
@@ -73,12 +73,11 @@ bool FontManager::Init(const std::string& szFontPath, IDriver3D *pDriver)
 void FontManager::Destroy()
 {
     //delete the fonts.
-    FontMap::iterator iFont = m_Fonts.begin();
-    FontMap::iterator eFont = m_Fonts.end();
-    for (; iFont != eFont; ++iFont)
+    for (auto &pair : m_Fonts)
     {
-        xlDelete (*iFont).second;
+        xlDelete pair.second;
     }
+
     m_Fonts.clear();
 
     if ( m_pVB )

--- a/render/MeshCache.cpp
+++ b/render/MeshCache.cpp
@@ -15,20 +15,18 @@ bool MeshCache::Init()
 
 void MeshCache::Destroy()
 {
-    MeshMap::iterator iMesh = m_MeshMap.begin();
-    MeshMap::iterator eMesh = m_MeshMap.end();
-    for (; iMesh != eMesh; ++iMesh)
+    for (auto &pair : m_MeshMap)
     {
-        delete iMesh->second;
+        delete pair.second;
     }
+
     m_MeshMap.clear();
 
-    MeshCollisionMap::iterator iMeshCol = m_MeshCollisionMap.begin();
-    MeshCollisionMap::iterator eMeshCol = m_MeshCollisionMap.end();
-    for (; iMeshCol != eMeshCol; ++iMeshCol)
+    for (auto &pair : m_MeshCollisionMap)
     {
-        delete iMeshCol->second;
+        delete pair.second;
     }
+
     m_MeshCollisionMap.clear();
 }
 

--- a/ui/UI_System.cpp
+++ b/ui/UI_System.cpp
@@ -98,21 +98,19 @@ void UI_System::Destroy()
         UI_FreeImage( Editor_UI_Atlas );
     }
 
-    std::vector<UI_Screen *>::iterator iScreen = m_ScreenList.begin();
-    std::vector<UI_Screen *>::iterator eScreen = m_ScreenList.end();
-    for (; iScreen != eScreen; ++iScreen)
+    for (UI_Screen *screen : m_ScreenList)
     {
-        xlDelete *iScreen;
+        xlDelete screen;
     }
+
     m_ScreenList.clear();
     m_ScreenMap.clear();
 
-    std::vector<UI_Window *>::iterator iWindow = m_WindowList.begin();
-    std::vector<UI_Window *>::iterator eWindow = m_WindowList.end();
-    for (; iWindow != eWindow; ++iWindow)
+    for (UI_Window *window : m_WindowList)
     {
-        xlDelete *iWindow;
+        xlDelete window;
     }
+
     m_WindowList.clear();
 
     FreeRenderFramePool();

--- a/world/LevelFunc.cpp
+++ b/world/LevelFunc.cpp
@@ -27,20 +27,14 @@ LevelFunc::LevelFunc(WorldCell *pWorldCell, int32_t nSector, int32_t nWall)
 
 LevelFunc::~LevelFunc()
 {
-    std::vector<State *>::iterator iState = m_States.begin();
-    std::vector<State *>::iterator eState = m_States.end();
-
-    for (; iState != eState; ++iState)
+    for (State *state : m_States)
     {
-        xlDelete (*iState);
+        xlDelete state;
     }
 
-    std::vector<ClientObject *>::iterator iCObj = m_ClientObjects.begin();
-    std::vector<ClientObject *>::iterator eCObj = m_ClientObjects.end();
-
-    for (; iCObj != eCObj; ++iCObj)
+    for (ClientObject *cObj : m_ClientObjects)
     {
-        xlDelete (*iCObj);
+        xlDelete cObj;
     }
 }
 

--- a/world/LevelFuncMgr.cpp
+++ b/world/LevelFuncMgr.cpp
@@ -23,12 +23,11 @@ void LevelFuncMgr::Destroy()
     m_AddList.clear();
     m_RemoveList.clear();
 
-    std::vector<LevelFunc *>::iterator iFunc = m_FuncList.begin();
-    std::vector<LevelFunc *>::iterator eFunc = m_FuncList.end();
-    for (; iFunc != eFunc; ++iFunc)
+    for (LevelFunc *func : m_FuncList)
     {
-        delete (*iFunc);
+        delete func;
     }
+
     m_FuncList.clear();
 }
 

--- a/world/LogicManager.cpp
+++ b/world/LogicManager.cpp
@@ -9,12 +9,9 @@ bool LogicManager::Init()
 
 void LogicManager::Destroy()
 {
-    std::map<std::string, Logic *>::iterator iLogic = m_Logics.begin();
-    std::map<std::string, Logic *>::iterator eLogic = m_Logics.end();
-
-    for (; iLogic != eLogic; ++iLogic)
+    for (auto &pair : m_Logics)
     {
-        xlDelete iLogic->second;
+        xlDelete pair.second;
     }
 
     m_Logics.clear();

--- a/world/ObjectManager.cpp
+++ b/world/ObjectManager.cpp
@@ -40,13 +40,11 @@ void ObjectManager::Destroy()
 {
     LogicManager::Destroy();
 
-    std::vector<Object *>::iterator iObjPool = m_ObjectPool.begin();
-    std::vector<Object *>::iterator eObjPool = m_ObjectPool.end();
-    for (; iObjPool != eObjPool; ++iObjPool)
+    for (Object *pool : m_ObjectPool)
     {
-        Object *pool = *iObjPool;
-        xlDelete [] pool;
+        xlDelete[] pool;
     }
+
     m_ObjectPool.clear();
     m_FreeObjects.clear();
     m_ActiveObjects.clear();

--- a/world/Sector.cpp
+++ b/world/Sector.cpp
@@ -15,12 +15,11 @@ Sector::Sector()
 
 Sector::~Sector()
 {
-    std::vector<LightObject *>::iterator iLight = m_Lights.begin();
-    std::vector<LightObject *>::iterator eLight = m_Lights.end();
-    for (; iLight != eLight; ++iLight)
+    for (LightObject *light : m_Lights)
     {
-        xlDelete *iLight;
+        xlDelete light;
     }
+
     m_Lights.clear();
     xlDelete [] m_pValidNodes;
 }

--- a/world/World.cpp
+++ b/world/World.cpp
@@ -32,12 +32,11 @@ World::~World()
 
 void World::UnloadWorldCells()
 {
-    std::vector<WorldCell *>::iterator iCell = m_WorldCells.begin();
-    std::vector<WorldCell *>::iterator eCell = m_WorldCells.end();
-    for (; iCell != eCell; ++iCell)
+    for (WorldCell *cell : m_WorldCells)
     {
-        xlDelete *iCell;
+        xlDelete cell;
     }
+
     m_WorldCells.clear();
 }
 


### PR DESCRIPTION
This was just for trivial cases in destructor-like methods. There are still many other places where iterator pairs could be changed to range-based for loops (and they will be converted eventually).

Ideally most (if not all) of these changes would be replaced by smart pointers at some point, but this is just the first iteration of changes. I haven't started changing any memory management stuff itself yet.