### PR TITLE
Add virtual, override, and default keywords

### DIFF
--- a/fileformats/ART_Reader.h
+++ b/fileformats/ART_Reader.h
@@ -10,18 +10,18 @@ class ART_Reader : public Archive
 public:
     ART_Reader();
 
-    virtual bool Open(const char *pszName) override;
-    virtual void Close() override;
+    bool Open(const char *pszName) override;
+    void Close() override;
 
-    virtual bool OpenFile(const char *pszFile) override;
-    virtual void CloseFile() override;
-    virtual uint32_t GetFileLen() override;
-    virtual bool ReadFile(void *pData, uint32_t uLength) override;
+    bool OpenFile(const char *pszFile) override;
+    void CloseFile() override;
+    uint32_t GetFileLen() override;
+    bool ReadFile(void *pData, uint32_t uLength) override;
 
-    virtual int32_t GetFileCount() override;
-    virtual const char *GetFileName(int32_t nFileIdx) override;
+    int32_t GetFileCount() override;
+    const char *GetFileName(int32_t nFileIdx) override;
 
-    virtual void *ReadFileInfo() override;
+    void *ReadFileInfo() override;
 
 private:
 

--- a/fileformats/ART_Reader.h
+++ b/fileformats/ART_Reader.h
@@ -10,18 +10,18 @@ class ART_Reader : public Archive
 public:
     ART_Reader();
 
-    bool Open(const char *pszName);
-    void Close();
+    virtual bool Open(const char *pszName) override;
+    virtual void Close() override;
 
-    bool OpenFile(const char *pszFile);
-    void CloseFile();
-    uint32_t GetFileLen();
-    bool ReadFile(void *pData, uint32_t uLength);
+    virtual bool OpenFile(const char *pszFile) override;
+    virtual void CloseFile() override;
+    virtual uint32_t GetFileLen() override;
+    virtual bool ReadFile(void *pData, uint32_t uLength) override;
 
-    int32_t GetFileCount();
-    const char *GetFileName(int32_t nFileIdx);
+    virtual int32_t GetFileCount() override;
+    virtual const char *GetFileName(int32_t nFileIdx) override;
 
-    void *ReadFileInfo();
+    virtual void *ReadFileInfo() override;
 
 private:
 

--- a/fileformats/BSA_Reader.h
+++ b/fileformats/BSA_Reader.h
@@ -10,19 +10,19 @@ class BSA_Reader : public Archive
 public:
     BSA_Reader();
 
-    virtual bool Open(const char *pszName) override;
-    virtual void Close() override;
+    bool Open(const char *pszName) override;
+    void Close() override;
 
-    virtual bool OpenFile(const char *pszFile) override;
-    virtual bool OpenFile(const uint32_t uID) override;
-    virtual bool SearchForFile(const char *pszFileIn, char *pszFileOut) override;
-    virtual void CloseFile() override;
-    virtual uint32_t GetFileLen() override;
-    virtual bool ReadFile(void *pData, uint32_t uLength) override;
+    bool OpenFile(const char *pszFile) override;
+    bool OpenFile(const uint32_t uID) override;
+    bool SearchForFile(const char *pszFileIn, char *pszFileOut) override;
+    void CloseFile() override;
+    uint32_t GetFileLen() override;
+    bool ReadFile(void *pData, uint32_t uLength) override;
 
-    virtual int32_t GetFileCount() override;
-    virtual const char *GetFileName(int32_t nFileIdx) override;
-    virtual uint32_t GetFileID(int32_t nFileIdx) override;
+    int32_t GetFileCount() override;
+    const char *GetFileName(int32_t nFileIdx) override;
+    uint32_t GetFileID(int32_t nFileIdx) override;
 
 private:
 

--- a/fileformats/BSA_Reader.h
+++ b/fileformats/BSA_Reader.h
@@ -10,19 +10,19 @@ class BSA_Reader : public Archive
 public:
     BSA_Reader();
 
-    bool Open(const char *pszName);
-    void Close();
+    virtual bool Open(const char *pszName) override;
+    virtual void Close() override;
 
-    bool OpenFile(const char *pszFile);
-    bool OpenFile(const uint32_t uID);
-    bool SearchForFile(const char *pszFileIn, char *pszFileOut);
-    void CloseFile();
-    uint32_t GetFileLen();
-    bool ReadFile(void *pData, uint32_t uLength);
+    virtual bool OpenFile(const char *pszFile) override;
+    virtual bool OpenFile(const uint32_t uID) override;
+    virtual bool SearchForFile(const char *pszFileIn, char *pszFileOut) override;
+    virtual void CloseFile() override;
+    virtual uint32_t GetFileLen() override;
+    virtual bool ReadFile(void *pData, uint32_t uLength) override;
 
-    int32_t GetFileCount();
-    const char *GetFileName(int32_t nFileIdx);
-    uint32_t GetFileID(int32_t nFileIdx);
+    virtual int32_t GetFileCount() override;
+    virtual const char *GetFileName(int32_t nFileIdx) override;
+    virtual uint32_t GetFileID(int32_t nFileIdx) override;
 
 private:
 

--- a/fileformats/CellLoader.h
+++ b/fileformats/CellLoader.h
@@ -10,14 +10,14 @@ class World;
 class CellLoader
 {
 public:
-    CellLoader() {};
-    virtual ~CellLoader() {};
+    CellLoader() = default;
+    virtual ~CellLoader() = default;
 
     //returns true if this CellLoader handles file handling itself.
     virtual bool UsesOwnFiles() { return false; }
     //load (normal)
-    virtual WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) {return 0;}
-    virtual WorldCell *LoadFromLocation(IDriver3D *pDriver, World *pWorld, void *pLocPtr) {return 0;}
+    virtual WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) {return nullptr;}
+    virtual WorldCell *LoadFromLocation(IDriver3D *pDriver, World *pWorld, void *pLocPtr) {return nullptr;}
 };
 
 #endif //CELLLOADER_H

--- a/fileformats/CellLoader_BloodMap.cpp
+++ b/fileformats/CellLoader_BloodMap.cpp
@@ -29,6 +29,10 @@ CellLoader_BloodMap::CellLoader_BloodMap() : CellLoader()
     m_pBloodSprites = nullptr;
 }
 
+CellLoader_BloodMap::~CellLoader_BloodMap()
+{
+}
+
 void CellLoader_BloodMap::DecryptBuffer(uint8_t *pBuffer, const uint32_t uDataSize, uint8_t uDecryptKey)
 {
     // Variables

--- a/fileformats/CellLoader_BloodMap.cpp
+++ b/fileformats/CellLoader_BloodMap.cpp
@@ -29,10 +29,6 @@ CellLoader_BloodMap::CellLoader_BloodMap() : CellLoader()
     m_pBloodSprites = nullptr;
 }
 
-CellLoader_BloodMap::~CellLoader_BloodMap()
-{
-}
-
 void CellLoader_BloodMap::DecryptBuffer(uint8_t *pBuffer, const uint32_t uDataSize, uint8_t uDecryptKey)
 {
     // Variables

--- a/fileformats/CellLoader_BloodMap.h
+++ b/fileformats/CellLoader_BloodMap.h
@@ -11,9 +11,9 @@ class CellLoader_BloodMap : public CellLoader
 {
 public:
     CellLoader_BloodMap();
-    ~CellLoader_BloodMap();
+    virtual ~CellLoader_BloodMap() = default;
 
-    WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY );
+    virtual WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) override;
 
 private:
     struct HeaderPart1

--- a/fileformats/CellLoader_BloodMap.h
+++ b/fileformats/CellLoader_BloodMap.h
@@ -11,9 +11,9 @@ class CellLoader_BloodMap : public CellLoader
 {
 public:
     CellLoader_BloodMap();
-    virtual ~CellLoader_BloodMap() = default;
+    virtual ~CellLoader_BloodMap();
 
-    virtual WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) override;
+    WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) override;
 
 private:
     struct HeaderPart1

--- a/fileformats/CellLoader_Daggerfall.cpp
+++ b/fileformats/CellLoader_Daggerfall.cpp
@@ -198,14 +198,6 @@ struct DT_ActionRecord
 
 #pragma pack(pop)
 
-CellLoader_Daggerfall::CellLoader_Daggerfall() : CellLoader()
-{
-}
-
-CellLoader_Daggerfall::~CellLoader_Daggerfall()
-{
-}
-
 WorldCell *CellLoader_Daggerfall::LoadFromLocation( IDriver3D *pDriver, World *pWorld, void *pLocPtr )
 {
     Location_Daggerfall *pLocation = (Location_Daggerfall *)pLocPtr;

--- a/fileformats/CellLoader_Daggerfall.cpp
+++ b/fileformats/CellLoader_Daggerfall.cpp
@@ -343,6 +343,10 @@ WorldCell *CellLoader_Daggerfall::LoadFromLocation( IDriver3D *pDriver, World *p
     return pCell;
 }
 
+CellLoader_Daggerfall::~CellLoader_Daggerfall()
+{
+}
+
 WorldCell *CellLoader_Daggerfall::Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY )
 {
     Location_Daggerfall *pLocation = WorldMap::GetLocation(sFile.c_str());

--- a/fileformats/CellLoader_Daggerfall.h
+++ b/fileformats/CellLoader_Daggerfall.h
@@ -12,14 +12,14 @@ class Sector;
 class CellLoader_Daggerfall : public CellLoader
 {
 public:
-    CellLoader_Daggerfall();
-    ~CellLoader_Daggerfall();
+    CellLoader_Daggerfall() = default;
+    virtual ~CellLoader_Daggerfall() = default;
 
-    WorldCell *Load(IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY);
-    WorldCell *LoadFromLocation(IDriver3D *pDriver, World *pWorld, void *pLocPtr);
+    virtual WorldCell *Load(IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY) override;
+    virtual WorldCell *LoadFromLocation(IDriver3D *pDriver, World *pWorld, void *pLocPtr) override;
 
     //returns true if this CellLoader handles file handling itself.
-    bool UsesOwnFiles() { return true; }
+    virtual bool UsesOwnFiles() override { return true; }
 
 private:
     Sector *LoadBlock(IDriver3D *pDriver, uint32_t uLength, int& index, char *pData, const Vector3& vBlockLoc, Vector3& vStartTagLoc, bool bStartBlock, int32_t worldX, int32_t worldY, int blockType);

--- a/fileformats/CellLoader_Daggerfall.h
+++ b/fileformats/CellLoader_Daggerfall.h
@@ -13,13 +13,13 @@ class CellLoader_Daggerfall : public CellLoader
 {
 public:
     CellLoader_Daggerfall() = default;
-    virtual ~CellLoader_Daggerfall() = default;
+    virtual ~CellLoader_Daggerfall();
 
-    virtual WorldCell *Load(IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY) override;
-    virtual WorldCell *LoadFromLocation(IDriver3D *pDriver, World *pWorld, void *pLocPtr) override;
+    WorldCell *Load(IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY) override;
+    WorldCell *LoadFromLocation(IDriver3D *pDriver, World *pWorld, void *pLocPtr) override;
 
     //returns true if this CellLoader handles file handling itself.
-    virtual bool UsesOwnFiles() override { return true; }
+    bool UsesOwnFiles() override { return true; }
 
 private:
     Sector *LoadBlock(IDriver3D *pDriver, uint32_t uLength, int& index, char *pData, const Vector3& vBlockLoc, Vector3& vStartTagLoc, bool bStartBlock, int32_t worldX, int32_t worldY, int blockType);

--- a/fileformats/CellLoader_OutlawsMap.cpp
+++ b/fileformats/CellLoader_OutlawsMap.cpp
@@ -23,14 +23,6 @@ const float m_fWorldToTexel_Z = 8.0f;
 
 #define MAX_WALLS 32768
 
-CellLoader_OutlawsMap::CellLoader_OutlawsMap() : CellLoader()
-{
-}
-
-CellLoader_OutlawsMap::~CellLoader_OutlawsMap()
-{
-}
-
 //Outlaws Sector Flags.
 enum
 {

--- a/fileformats/CellLoader_OutlawsMap.cpp
+++ b/fileformats/CellLoader_OutlawsMap.cpp
@@ -191,6 +191,10 @@ TextureHandle LoadNWX(uint8_t *pData, uint32_t uLen, const char *pszName, uint32
     //CELL_NWX *pCell2 = (CELL_NWX *)&pData[48+sizeof(CELL_NWX)+pCell0->size+4 + sizeof(CELL_NWX)+pCell1->size+4];
 }
 
+CellLoader_OutlawsMap::~CellLoader_OutlawsMap()
+{
+}
+
 WorldCell *CellLoader_OutlawsMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY )
 {
     WorldCell *pCell = nullptr;

--- a/fileformats/CellLoader_OutlawsMap.h
+++ b/fileformats/CellLoader_OutlawsMap.h
@@ -11,9 +11,9 @@ class CellLoader_OutlawsMap : public CellLoader
 {
 public:
     CellLoader_OutlawsMap() = default;
-    virtual ~CellLoader_OutlawsMap() = default;
+    virtual ~CellLoader_OutlawsMap();
 
-    virtual WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) override;
+    WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) override;
 
 private:
 

--- a/fileformats/CellLoader_OutlawsMap.h
+++ b/fileformats/CellLoader_OutlawsMap.h
@@ -10,10 +10,10 @@ class World;
 class CellLoader_OutlawsMap : public CellLoader
 {
 public:
-    CellLoader_OutlawsMap();
-    ~CellLoader_OutlawsMap();
+    CellLoader_OutlawsMap() = default;
+    virtual ~CellLoader_OutlawsMap() = default;
 
-    WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY );
+    virtual WorldCell *Load( IDriver3D *pDriver, World *pWorld, uint8_t *pData, uint32_t uLen, const std::string& sFile, int32_t worldX, int32_t worldY ) override;
 
 private:
 

--- a/fileformats/GOB_Reader.h
+++ b/fileformats/GOB_Reader.h
@@ -11,16 +11,16 @@ class GOB_Reader : public Archive
 public:
     GOB_Reader();
 
-    virtual bool Open(const char *pszName) override;
-    virtual void Close() override;
+    bool Open(const char *pszName) override;
+    void Close() override;
 
-    virtual bool OpenFile(const char *pszFile) override;
-    virtual void CloseFile() override;
-    virtual uint32_t GetFileLen() override;
-    virtual bool ReadFile(void *pData, uint32_t uLength) override;
+    bool OpenFile(const char *pszFile) override;
+    void CloseFile() override;
+    uint32_t GetFileLen() override;
+    bool ReadFile(void *pData, uint32_t uLength) override;
 
-    virtual int32_t GetFileCount() override;
-    virtual const char *GetFileName(int32_t nFileIdx) override;
+    int32_t GetFileCount() override;
+    const char *GetFileName(int32_t nFileIdx) override;
 
 private:
 

--- a/fileformats/GOB_Reader.h
+++ b/fileformats/GOB_Reader.h
@@ -11,16 +11,16 @@ class GOB_Reader : public Archive
 public:
     GOB_Reader();
 
-    bool Open(const char *pszName);
-    void Close();
+    virtual bool Open(const char *pszName) override;
+    virtual void Close() override;
 
-    bool OpenFile(const char *pszFile);
-    void CloseFile();
-    uint32_t GetFileLen();
-    bool ReadFile(void *pData, uint32_t uLength);
+    virtual bool OpenFile(const char *pszFile) override;
+    virtual void CloseFile() override;
+    virtual uint32_t GetFileLen() override;
+    virtual bool ReadFile(void *pData, uint32_t uLength) override;
 
-    int32_t GetFileCount();
-    const char *GetFileName(int32_t nFileIdx);
+    virtual int32_t GetFileCount() override;
+    virtual const char *GetFileName(int32_t nFileIdx) override;
 
 private:
 

--- a/fileformats/LFD_Reader.h
+++ b/fileformats/LFD_Reader.h
@@ -10,13 +10,13 @@ class LFD_Reader : public Archive
 public:
     LFD_Reader();
 
-    virtual bool Open(const char *pszName) override;
-    virtual void Close() override;
+    bool Open(const char *pszName) override;
+    void Close() override;
 
-    virtual bool OpenFile(const char *pszFile) override;
-    virtual void CloseFile() override;
-    virtual uint32_t GetFileLen() override;
-    virtual bool ReadFile(void *pData, uint32_t uLength) override;
+    bool OpenFile(const char *pszFile) override;
+    void CloseFile() override;
+    uint32_t GetFileLen() override;
+    bool ReadFile(void *pData, uint32_t uLength) override;
 
 private:
 

--- a/fileformats/LFD_Reader.h
+++ b/fileformats/LFD_Reader.h
@@ -10,13 +10,13 @@ class LFD_Reader : public Archive
 public:
     LFD_Reader();
 
-    bool Open(const char *pszName);
-    void Close();
+    virtual bool Open(const char *pszName) override;
+    virtual void Close() override;
 
-    bool OpenFile(const char *pszFile);
-    void CloseFile();
-    uint32_t GetFileLen();
-    bool ReadFile(void *pData, uint32_t uLength);
+    virtual bool OpenFile(const char *pszFile) override;
+    virtual void CloseFile() override;
+    virtual uint32_t GetFileLen() override;
+    virtual bool ReadFile(void *pData, uint32_t uLength) override;
 
 private:
 

--- a/fileformats/RFF_Reader.h
+++ b/fileformats/RFF_Reader.h
@@ -10,18 +10,18 @@ class RFF_Reader : public Archive
 public:
     RFF_Reader();
 
-    bool Open(const char *pszName);
-    void Close();
+    virtual bool Open(const char *pszName) override;
+    virtual void Close() override;
 
-    bool OpenFile(const char *pszFile);
-    void CloseFile();
-    uint32_t GetFileLen();
-    bool ReadFile(void *pData, uint32_t uLength);
+    virtual bool OpenFile(const char *pszFile) override;
+    virtual void CloseFile() override;
+    virtual uint32_t GetFileLen() override;
+    virtual bool ReadFile(void *pData, uint32_t uLength) override;
 
-    int32_t GetFileCount();
-    const char *GetFileName(int32_t nFileIdx);
+    virtual int32_t GetFileCount() override;
+    virtual const char *GetFileName(int32_t nFileIdx) override;
 
-    void *ReadFileInfo();
+    virtual void *ReadFileInfo() override;
 
 private:
 

--- a/fileformats/RFF_Reader.h
+++ b/fileformats/RFF_Reader.h
@@ -10,18 +10,18 @@ class RFF_Reader : public Archive
 public:
     RFF_Reader();
 
-    virtual bool Open(const char *pszName) override;
-    virtual void Close() override;
+    bool Open(const char *pszName) override;
+    void Close() override;
 
-    virtual bool OpenFile(const char *pszFile) override;
-    virtual void CloseFile() override;
-    virtual uint32_t GetFileLen() override;
-    virtual bool ReadFile(void *pData, uint32_t uLength) override;
+    bool OpenFile(const char *pszFile) override;
+    void CloseFile() override;
+    uint32_t GetFileLen() override;
+    bool ReadFile(void *pData, uint32_t uLength) override;
 
-    virtual int32_t GetFileCount() override;
-    virtual const char *GetFileName(int32_t nFileIdx) override;
+    int32_t GetFileCount() override;
+    const char *GetFileName(int32_t nFileIdx) override;
 
-    virtual void *ReadFileInfo() override;
+    void *ReadFileInfo() override;
 
 private:
 

--- a/fileformats/SkyLoader.h
+++ b/fileformats/SkyLoader.h
@@ -6,8 +6,8 @@
 class SkyLoader
 {
 public:
-    SkyLoader() {};
-    virtual ~SkyLoader() {};
+    SkyLoader() = default;
+    virtual ~SkyLoader() = default;
 
     virtual bool LoadSky(int32_t regionID) {return false;}
     virtual void *GetSkyData(int32_t regionID) {return 0;}

--- a/fileformats/SkyLoader_Daggerfall.cpp
+++ b/fileformats/SkyLoader_Daggerfall.cpp
@@ -18,6 +18,10 @@ SkyLoader_Daggerfall::SkyLoader_Daggerfall() : SkyLoader()
     }
 }
 
+SkyLoader_Daggerfall::~SkyLoader_Daggerfall()
+{
+}
+
 bool SkyLoader_Daggerfall::LoadSky(int32_t regionID)
 {
     if ( m_aSkyData[regionID].bLoaded )

--- a/fileformats/SkyLoader_Daggerfall.cpp
+++ b/fileformats/SkyLoader_Daggerfall.cpp
@@ -18,10 +18,6 @@ SkyLoader_Daggerfall::SkyLoader_Daggerfall() : SkyLoader()
     }
 }
 
-SkyLoader_Daggerfall::~SkyLoader_Daggerfall()
-{
-}
-
 bool SkyLoader_Daggerfall::LoadSky(int32_t regionID)
 {
     if ( m_aSkyData[regionID].bLoaded )

--- a/fileformats/SkyLoader_Daggerfall.h
+++ b/fileformats/SkyLoader_Daggerfall.h
@@ -17,10 +17,10 @@ class SkyLoader_Daggerfall : public SkyLoader
 {
 public:
     SkyLoader_Daggerfall();
-    ~SkyLoader_Daggerfall();
+    virtual ~SkyLoader_Daggerfall() = default;
 
-    bool LoadSky(int32_t regionID);
-    void *GetSkyData(int32_t regionID);
+    virtual bool LoadSky(int32_t regionID) override;
+    virtual void *GetSkyData(int32_t regionID) override;
 
 private:
     enum

--- a/fileformats/SkyLoader_Daggerfall.h
+++ b/fileformats/SkyLoader_Daggerfall.h
@@ -17,10 +17,10 @@ class SkyLoader_Daggerfall : public SkyLoader
 {
 public:
     SkyLoader_Daggerfall();
-    virtual ~SkyLoader_Daggerfall() = default;
+    virtual ~SkyLoader_Daggerfall();
 
-    virtual bool LoadSky(int32_t regionID) override;
-    virtual void *GetSkyData(int32_t regionID) override;
+    bool LoadSky(int32_t regionID) override;
+    void *GetSkyData(int32_t regionID) override;
 
 private:
     enum

--- a/fileformats/TextureConv_ART.cpp
+++ b/fileformats/TextureConv_ART.cpp
@@ -1,6 +1,10 @@
 #include "TextureConv_ART.h"
 #include "ArchiveManager.h"
 
+TextureConv_ART::~TextureConv_ART()
+{
+}
+
 bool TextureConv_ART::ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID/*=0*/)
 {
     uint16_t *pSizeInfo = (uint16_t *)ArchiveManager::GameFile_GetFileInfo();

--- a/fileformats/TextureConv_ART.cpp
+++ b/fileformats/TextureConv_ART.cpp
@@ -1,14 +1,6 @@
 #include "TextureConv_ART.h"
 #include "ArchiveManager.h"
 
-TextureConv_ART::TextureConv_ART() : TextureConverter()
-{
-}
-
-TextureConv_ART::~TextureConv_ART()
-{
-}
-
 bool TextureConv_ART::ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID/*=0*/)
 {
     uint16_t *pSizeInfo = (uint16_t *)ArchiveManager::GameFile_GetFileInfo();

--- a/fileformats/TextureConv_ART.h
+++ b/fileformats/TextureConv_ART.h
@@ -7,9 +7,9 @@ class TextureConv_ART : public TextureConverter
 {
 public:
     TextureConv_ART() = default;
-    virtual ~TextureConv_ART() = default;
+    virtual ~TextureConv_ART();
 
-    virtual bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
+    bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
 };
 
 #endif //TEXTURECONVERTER_ART_H

--- a/fileformats/TextureConv_ART.h
+++ b/fileformats/TextureConv_ART.h
@@ -6,10 +6,10 @@
 class TextureConv_ART : public TextureConverter
 {
 public:
-    TextureConv_ART();
-    ~TextureConv_ART();
+    TextureConv_ART() = default;
+    virtual ~TextureConv_ART() = default;
 
-    bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0);
+    virtual bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
 };
 
 #endif //TEXTURECONVERTER_ART_H

--- a/fileformats/TextureConv_IMG.cpp
+++ b/fileformats/TextureConv_IMG.cpp
@@ -34,6 +34,10 @@ struct ImageHeader
 
 #pragma pack(pop)
 
+TextureConv_IMG::~TextureConv_IMG()
+{
+}
+
 uint32_t TextureConv_IMG::GetHackID(const char *pszImage)
 {
     uint32_t uHackID = 0;

--- a/fileformats/TextureConv_IMG.cpp
+++ b/fileformats/TextureConv_IMG.cpp
@@ -34,14 +34,6 @@ struct ImageHeader
 
 #pragma pack(pop)
 
-TextureConv_IMG::TextureConv_IMG() : TextureConverter()
-{
-}
-
-TextureConv_IMG::~TextureConv_IMG()
-{
-}
-
 uint32_t TextureConv_IMG::GetHackID(const char *pszImage)
 {
     uint32_t uHackID = 0;

--- a/fileformats/TextureConv_IMG.h
+++ b/fileformats/TextureConv_IMG.h
@@ -6,17 +6,17 @@
 class TextureConv_IMG : public TextureConverter
 {
 public:
-    TextureConv_IMG();
-    ~TextureConv_IMG();
+    TextureConv_IMG() = default;
+    virtual ~TextureConv_IMG() = default;
 
-    uint32_t GetHackID(const char *pszImage);
-    bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0);
-    bool ConvertTexture_Pal8_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, int nRecord, uint32_t uHackID=0);
+    virtual uint32_t GetHackID(const char *pszImage) override;
+    virtual bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
+    virtual bool ConvertTexture_Pal8_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, int nRecord, uint32_t uHackID=0) override;
 
-    bool ConvertTexture_8bpp(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, uint32_t uHackID=0);
-    uint32_t  ConvertTexture_8bpp_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, int nRecord, uint32_t uHackID=0);
+    virtual bool ConvertTexture_8bpp(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, uint32_t uHackID=0) override;
+    virtual uint32_t  ConvertTexture_8bpp_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, int nRecord, uint32_t uHackID=0) override;
     //Get extra game/format specific data.
-    virtual void *GetExtraTexData(uint32_t& uDataSize) { uDataSize=4; return m_aExtraData; }
+    virtual void *GetExtraTexData(uint32_t& uDataSize) override { uDataSize=4; return m_aExtraData; }
 private:
     int16_t m_aExtraData[2];
 };

--- a/fileformats/TextureConv_IMG.h
+++ b/fileformats/TextureConv_IMG.h
@@ -7,16 +7,16 @@ class TextureConv_IMG : public TextureConverter
 {
 public:
     TextureConv_IMG() = default;
-    virtual ~TextureConv_IMG() = default;
+    virtual ~TextureConv_IMG();
 
-    virtual uint32_t GetHackID(const char *pszImage) override;
-    virtual bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
-    virtual bool ConvertTexture_Pal8_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, int nRecord, uint32_t uHackID=0) override;
+    uint32_t GetHackID(const char *pszImage) override;
+    bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
+    bool ConvertTexture_Pal8_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, int nRecord, uint32_t uHackID=0) override;
 
-    virtual bool ConvertTexture_8bpp(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, uint32_t uHackID=0) override;
-    virtual uint32_t  ConvertTexture_8bpp_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, int nRecord, uint32_t uHackID=0) override;
+    bool ConvertTexture_8bpp(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, uint32_t uHackID=0) override;
+    uint32_t  ConvertTexture_8bpp_TexList(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, int nRecord, uint32_t uHackID=0) override;
     //Get extra game/format specific data.
-    virtual void *GetExtraTexData(uint32_t& uDataSize) override { uDataSize=4; return m_aExtraData; }
+    void *GetExtraTexData(uint32_t& uDataSize) override { uDataSize=4; return m_aExtraData; }
 private:
     int16_t m_aExtraData[2];
 };

--- a/fileformats/TextureConv_PCX.cpp
+++ b/fileformats/TextureConv_PCX.cpp
@@ -26,6 +26,10 @@ struct PCX_Header
     uint8_t Filler[56];     //128
 };
 
+TextureConv_PCX::~TextureConv_PCX()
+{
+}
+
 bool TextureConv_PCX::ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID/*=0*/)
 {
     PCX_Header *pHeader = (PCX_Header *)pSourceData;

--- a/fileformats/TextureConv_PCX.cpp
+++ b/fileformats/TextureConv_PCX.cpp
@@ -5,14 +5,6 @@
 #include <cassert>
 #include <cstring>
 
-TextureConv_PCX::TextureConv_PCX() : TextureConverter()
-{
-}
-
-TextureConv_PCX::~TextureConv_PCX()
-{
-}
-
 struct PCX_Header
 {
     uint8_t Manufacturer;

--- a/fileformats/TextureConv_PCX.h
+++ b/fileformats/TextureConv_PCX.h
@@ -7,9 +7,9 @@ class TextureConv_PCX : public TextureConverter
 {
 public:
     TextureConv_PCX() = default;
-    virtual ~TextureConv_PCX() = default;
+    virtual ~TextureConv_PCX();
 
-    virtual bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
+    bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
 };
 
 #endif //TEXTURECONVERTER_PCX_H

--- a/fileformats/TextureConv_PCX.h
+++ b/fileformats/TextureConv_PCX.h
@@ -6,10 +6,10 @@
 class TextureConv_PCX : public TextureConverter
 {
 public:
-    TextureConv_PCX();
-    ~TextureConv_PCX();
+    TextureConv_PCX() = default;
+    virtual ~TextureConv_PCX() = default;
 
-    bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0);
+    virtual bool ConvertTexture_Pal8(uint8_t *pConvertedData, int32_t& nOffsX, int32_t& nOffsY, uint32_t& uWidth, uint32_t& uHeight, const uint8_t *pSourceData, uint32_t uLen, const uint8_t *pPalette, bool bCopyPal, uint32_t uHackID=0) override;
 };
 
 #endif //TEXTURECONVERTER_PCX_H

--- a/fileformats/TextureConverter.h
+++ b/fileformats/TextureConverter.h
@@ -6,8 +6,8 @@
 class TextureConverter
 {
 public:
-    TextureConverter()  {};
-    virtual ~TextureConverter() {};
+    TextureConverter() = default;
+    virtual ~TextureConverter() = default;
 
     //Some games have weird format deviations that must be discovered based on the file name.
     //These are "data hacks" that cannot be fixed without changing the data.

--- a/movieplayback/LFD_Film.h
+++ b/movieplayback/LFD_Film.h
@@ -16,11 +16,11 @@ class LFD_Film : public MoviePlayer
 public:
     LFD_Film(IDriver3D *pDriver);
 
-    bool Start(Archive *pRes0, Archive *pRes1, const char *pszFile, uint32_t uFlags, int32_t nSpeed);
-    void Stop();
+    virtual bool Start(Archive *pRes0, Archive *pRes1, const char *pszFile, uint32_t uFlags, int32_t nSpeed) override;
+    virtual void Stop() override;
 
-    bool Update();
-    void Render(float fDeltaTime);
+    virtual bool Update() override;
+    virtual void Render(float fDeltaTime) override;
 
 private:
     struct FilmEntry

--- a/movieplayback/LFD_Film.h
+++ b/movieplayback/LFD_Film.h
@@ -16,11 +16,11 @@ class LFD_Film : public MoviePlayer
 public:
     LFD_Film(IDriver3D *pDriver);
 
-    virtual bool Start(Archive *pRes0, Archive *pRes1, const char *pszFile, uint32_t uFlags, int32_t nSpeed) override;
-    virtual void Stop() override;
+    bool Start(Archive *pRes0, Archive *pRes1, const char *pszFile, uint32_t uFlags, int32_t nSpeed) override;
+    void Stop() override;
 
-    virtual bool Update() override;
-    virtual void Render(float fDeltaTime) override;
+    bool Update() override;
+    void Render(float fDeltaTime) override;
 
 private:
     struct FilmEntry

--- a/render/Driver3D_IPlatform.h
+++ b/render/Driver3D_IPlatform.h
@@ -6,8 +6,8 @@
 class Driver3D_IPlatform
 {
     public:
-        Driver3D_IPlatform() {}
-        virtual ~Driver3D_IPlatform() {}
+        Driver3D_IPlatform() = default;
+        virtual ~Driver3D_IPlatform() = default;
 
         virtual void SetWindowData(int32_t nParam, void **param) {}
 

--- a/render/Driver3D_OGL.h
+++ b/render/Driver3D_OGL.h
@@ -18,57 +18,57 @@ class Driver3D_OGL : public IDriver3D
         Driver3D_OGL();
         virtual ~Driver3D_OGL();
 
-        virtual bool Init(int32_t w, int32_t h) override;
-        virtual void Present() override;
-        virtual void Clear(bool bClearColor=true) override;
+        bool Init(int32_t w, int32_t h) override;
+        void Present() override;
+        void Clear(bool bClearColor=true) override;
 
-        virtual void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
-        virtual void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
-        virtual void SetProjMtx(Matrix *pMtx) override;
-        virtual void SetCamera(Camera *pCamera) override;
+        void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
+        void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
+        void SetProjMtx(Matrix *pMtx) override;
+        void SetCamera(Camera *pCamera) override;
 
-        virtual void ChangeWindowSize(int32_t w, int32_t h) override;
+        void ChangeWindowSize(int32_t w, int32_t h) override;
 
         //Texture Functions.
-        virtual void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
-        virtual void SetColor(Vector4 *pColor=0) override;
-        virtual TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
-        virtual void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
-        virtual void FreeTexture(TextureHandle hTex) override;
+        void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
+        void SetColor(Vector4 *pColor=0) override;
+        TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
+        void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
+        void FreeTexture(TextureHandle hTex) override;
 
         //VBO/IBO Support.
-        virtual uint32_t CreateVBO() override;
-        virtual void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic) override;
-        virtual void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
-        virtual void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags) override;
-        virtual uint32_t CreateIB() override;
-        virtual void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
-        virtual void DeleteBuffer(uint32_t uID) override;
-        virtual void ClearDrawData() override;
+        uint32_t CreateVBO() override;
+        void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic) override;
+        void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags) override;
+        uint32_t CreateIB() override;
+        void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        void DeleteBuffer(uint32_t uID) override;
+        void ClearDrawData() override;
 
         //Draw!
-        virtual void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0) override;
-        virtual void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot) override;
-        virtual void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color) override;
-        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false) override;
-        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false) override;
+        void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0) override;
+        void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot) override;
+        void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color) override;
+        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false) override;
+        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false) override;
 
         //Render States
-        virtual void EnableDepthWrite(bool bEnable) override;
-        virtual void EnableDepthRead(bool bEnable) override;
-        virtual void EnableStencilWriting(bool bEnable, uint32_t uValue) override;
-        virtual void EnableStencilTesting(bool bEnable) override;
-        virtual void EnableCulling(bool bEnable) override;
-        virtual void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128) override;
-        virtual void SetBlendMode(uint32_t uMode=BLEND_NONE) override;
-        virtual void EnableFog(bool bEnable, float fEnd=10000.0f) override;
-        virtual void SetFogDensity(float fDensity=1.0f) override;
+        void EnableDepthWrite(bool bEnable) override;
+        void EnableDepthRead(bool bEnable) override;
+        void EnableStencilWriting(bool bEnable, uint32_t uValue) override;
+        void EnableStencilTesting(bool bEnable) override;
+        void EnableCulling(bool bEnable) override;
+        void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128) override;
+        void SetBlendMode(uint32_t uMode=BLEND_NONE) override;
+        void EnableFog(bool bEnable, float fEnd=10000.0f) override;
+        void SetFogDensity(float fDensity=1.0f) override;
 
         //Sorting
-        virtual bool ApplyOpaqueSort() override { return true; }
-        virtual bool ApplyTransSort() override { return true; }
+        bool ApplyOpaqueSort() override { return true; }
+        bool ApplyTransSort() override { return true; }
 
-        virtual Camera *GetCamera() override { return m_pRenderCamera; }
+        Camera *GetCamera() override { return m_pRenderCamera; }
 
     protected:
 

--- a/render/Driver3D_OGL.h
+++ b/render/Driver3D_OGL.h
@@ -18,57 +18,57 @@ class Driver3D_OGL : public IDriver3D
         Driver3D_OGL();
         virtual ~Driver3D_OGL();
 
-        bool Init(int32_t w, int32_t h);
-        void Present();
-        void Clear(bool bClearColor=true);
+        virtual bool Init(int32_t w, int32_t h) override;
+        virtual void Present() override;
+        virtual void Clear(bool bClearColor=true) override;
 
-        void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY);
-        void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir);
-        void SetProjMtx(Matrix *pMtx);
-        void SetCamera(Camera *pCamera);
+        virtual void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
+        virtual void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
+        virtual void SetProjMtx(Matrix *pMtx) override;
+        virtual void SetCamera(Camera *pCamera) override;
 
-        void ChangeWindowSize(int32_t w, int32_t h);
+        virtual void ChangeWindowSize(int32_t w, int32_t h) override;
 
         //Texture Functions.
-        void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1);
-        void SetColor(Vector4 *pColor=0);
-        TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1);
-        void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false);
-        void FreeTexture(TextureHandle hTex);
+        virtual void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
+        virtual void SetColor(Vector4 *pColor=0) override;
+        virtual TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
+        virtual void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
+        virtual void FreeTexture(TextureHandle hTex) override;
 
         //VBO/IBO Support.
-        uint32_t CreateVBO();
-        void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic);
-        void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic);
-        void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags);
-        uint32_t CreateIB();
-        void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic);
-        void DeleteBuffer(uint32_t uID);
-        void ClearDrawData();
+        virtual uint32_t CreateVBO() override;
+        virtual void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic) override;
+        virtual void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        virtual void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags) override;
+        virtual uint32_t CreateIB() override;
+        virtual void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        virtual void DeleteBuffer(uint32_t uID) override;
+        virtual void ClearDrawData() override;
 
         //Draw!
-        void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0);
-        void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot);
-        void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color);
-        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false);
-        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false);
+        virtual void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0) override;
+        virtual void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot) override;
+        virtual void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color) override;
+        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false) override;
+        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false) override;
 
         //Render States
-        void EnableDepthWrite(bool bEnable);
-        void EnableDepthRead(bool bEnable);
-        void EnableStencilWriting(bool bEnable, uint32_t uValue);
-        void EnableStencilTesting(bool bEnable);
-        void EnableCulling(bool bEnable);
-        void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128);
-        void SetBlendMode(uint32_t uMode=BLEND_NONE);
-        void EnableFog(bool bEnable, float fEnd=10000.0f);
-        void SetFogDensity(float fDensity=1.0f);
+        virtual void EnableDepthWrite(bool bEnable) override;
+        virtual void EnableDepthRead(bool bEnable) override;
+        virtual void EnableStencilWriting(bool bEnable, uint32_t uValue) override;
+        virtual void EnableStencilTesting(bool bEnable) override;
+        virtual void EnableCulling(bool bEnable) override;
+        virtual void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128) override;
+        virtual void SetBlendMode(uint32_t uMode=BLEND_NONE) override;
+        virtual void EnableFog(bool bEnable, float fEnd=10000.0f) override;
+        virtual void SetFogDensity(float fDensity=1.0f) override;
 
         //Sorting
-        bool ApplyOpaqueSort() { return true; }
-        bool ApplyTransSort()  { return true; }
+        virtual bool ApplyOpaqueSort() override { return true; }
+        virtual bool ApplyTransSort() override { return true; }
 
-        Camera *GetCamera() { return m_pRenderCamera; }
+        virtual Camera *GetCamera() override { return m_pRenderCamera; }
 
     protected:
 

--- a/render/Driver3D_Soft.h
+++ b/render/Driver3D_Soft.h
@@ -44,56 +44,56 @@ class Driver3D_Soft : public IDriver3D
         Driver3D_Soft();
         virtual ~Driver3D_Soft();
 
-        bool Init(int32_t w, int32_t h);
-        void Present();
-        void Clear(bool bClearColor=true);
+        virtual bool Init(int32_t w, int32_t h) override;
+        virtual void Present() override;
+        virtual void Clear(bool bClearColor=true) override;
 
-        void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY);
-        void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir);
-        void SetProjMtx(Matrix *pMtx);
-        void SetCamera(Camera *pCamera);
+        virtual void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
+        virtual void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
+        virtual void SetProjMtx(Matrix *pMtx) override;
+        virtual void SetCamera(Camera *pCamera) override;
         
-        void ChangeWindowSize(int32_t w, int32_t h);
+        virtual void ChangeWindowSize(int32_t w, int32_t h) override;
 
         //Texture Functions.
-        void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1);
-        void SetColor(Vector4 *pColor=0);
-        TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1);
-        void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false);
-        void FreeTexture(TextureHandle hTex);
+        virtual void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
+        virtual void SetColor(Vector4 *pColor=0) override;
+        virtual TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
+        virtual void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
+        virtual void FreeTexture(TextureHandle hTex) override;
 
         //VBO/IBO Support.
-        uint32_t CreateVBO();
-        void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic);
-        void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic);
-        void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags);
-        uint32_t CreateIB();
-        void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic);
-        void ResetIBFlags(uint32_t uID);
-        void DeleteBuffer(uint32_t uID);
-        void ClearDrawData();
+        virtual uint32_t CreateVBO() override;
+        virtual void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic) override;
+        virtual void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        virtual void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags) override;
+        virtual uint32_t CreateIB() override;
+        virtual void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        virtual void ResetIBFlags(uint32_t uID) override;
+        virtual void DeleteBuffer(uint32_t uID) override;
+        virtual void ClearDrawData() override;
 
         //Draw!
-        void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0);
-        void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot);
-        void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color);
-        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false);
-        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false);
+        virtual void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0) override;
+        virtual void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot) override;
+        virtual void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color) override;
+        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false) override;
+        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false) override;
 
         //Render States
-        void EnableDepthWrite(bool bEnable);
-        void EnableDepthRead(bool bEnable);
-        void EnableStencilWriting(bool bEnable, uint32_t uValue);
-        void EnableStencilTesting(bool bEnable);
-        void EnableCulling(bool bEnable);
-        void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128);
-        void SetBlendMode(uint32_t uMode=BLEND_NONE);
-        void EnableFog(bool bEnable, float fEnd=10000.0f);
-        void SetFogDensity(float fDensity=1.0f);
+        virtual void EnableDepthWrite(bool bEnable) override;
+        virtual void EnableDepthRead(bool bEnable) override;
+        virtual void EnableStencilWriting(bool bEnable, uint32_t uValue) override;
+        virtual void EnableStencilTesting(bool bEnable) override;
+        virtual void EnableCulling(bool bEnable) override;
+        virtual void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128) override;
+        virtual void SetBlendMode(uint32_t uMode=BLEND_NONE) override;
+        virtual void EnableFog(bool bEnable, float fEnd=10000.0f) override;
+        virtual void SetFogDensity(float fDensity=1.0f) override;
 
         //Sorting
-        bool ApplyOpaqueSort() { return false; }
-        bool ApplyTransSort()  { return false; }
+        virtual bool ApplyOpaqueSort() override { return false; }
+        virtual bool ApplyTransSort() override { return false; }
 
         //Software Rendering specific.
         void SetBitDepth(int32_t bitDepth);
@@ -110,7 +110,7 @@ class Driver3D_Soft : public IDriver3D
         static Texture *GetCurTex() { return m_pCurTex; }
 
         //Driver extensions
-        void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1);
+        virtual void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1) override;
 
     protected:
 

--- a/render/Driver3D_Soft.h
+++ b/render/Driver3D_Soft.h
@@ -95,6 +95,8 @@ class Driver3D_Soft : public IDriver3D
         virtual bool ApplyOpaqueSort() override { return false; }
         virtual bool ApplyTransSort() override { return false; }
 
+        virtual Camera *GetCamera() override { return m_pRenderCamera; }
+
         //Software Rendering specific.
         void SetBitDepth(int32_t bitDepth);
         int32_t GetBitDepth() { return m_nBitDepth; }
@@ -103,7 +105,6 @@ class Driver3D_Soft : public IDriver3D
         int GetFrameHeight();
         bool GetBilinear() { return m_bBilinear; }
         bool GetGouraud()  { return m_bGouraud; }
-        Camera *GetCamera() { return m_pRenderCamera; }
         void SetClearColorFromTex(TextureHandle hTex);
         //optional polygon data to accelerate triangle processing.
         static uint8_t GetColormapID() { return s_uColormapID; }

--- a/render/Driver3D_Soft.h
+++ b/render/Driver3D_Soft.h
@@ -44,58 +44,58 @@ class Driver3D_Soft : public IDriver3D
         Driver3D_Soft();
         virtual ~Driver3D_Soft();
 
-        virtual bool Init(int32_t w, int32_t h) override;
-        virtual void Present() override;
-        virtual void Clear(bool bClearColor=true) override;
+        bool Init(int32_t w, int32_t h) override;
+        void Present() override;
+        void Clear(bool bClearColor=true) override;
 
-        virtual void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
-        virtual void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
-        virtual void SetProjMtx(Matrix *pMtx) override;
-        virtual void SetCamera(Camera *pCamera) override;
+        void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
+        void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
+        void SetProjMtx(Matrix *pMtx) override;
+        void SetCamera(Camera *pCamera) override;
         
-        virtual void ChangeWindowSize(int32_t w, int32_t h) override;
+        void ChangeWindowSize(int32_t w, int32_t h) override;
 
         //Texture Functions.
-        virtual void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
-        virtual void SetColor(Vector4 *pColor=0) override;
-        virtual TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
-        virtual void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
-        virtual void FreeTexture(TextureHandle hTex) override;
+        void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
+        void SetColor(Vector4 *pColor=0) override;
+        TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
+        void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
+        void FreeTexture(TextureHandle hTex) override;
 
         //VBO/IBO Support.
-        virtual uint32_t CreateVBO() override;
-        virtual void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic) override;
-        virtual void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
-        virtual void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags) override;
-        virtual uint32_t CreateIB() override;
-        virtual void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
-        virtual void ResetIBFlags(uint32_t uID) override;
-        virtual void DeleteBuffer(uint32_t uID) override;
-        virtual void ClearDrawData() override;
+        uint32_t CreateVBO() override;
+        void AllocVBO_Mem(uint32_t uID, uint32_t uVtxCnt, uint32_t uSize, bool bDynamic) override;
+        void FillVBO(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags) override;
+        uint32_t CreateIB() override;
+        void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        void ResetIBFlags(uint32_t uID) override;
+        void DeleteBuffer(uint32_t uID) override;
+        void ClearDrawData() override;
 
         //Draw!
-        virtual void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0) override;
-        virtual void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot) override;
-        virtual void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color) override;
-        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false) override;
-        virtual void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false) override;
+        void RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex=0) override;
+        void RenderScreenQuad(const Vector4& posScale, const Vector2& uvTop, const Vector2& uvBot, const Vector4& colorTop, const Vector4& colorBot) override;
+        void RenderWorldQuad(const Vector3& pos0, const Vector3& pos1, const Vector2& uv0, const Vector2& uv1, const Vector4& color) override;
+        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4& color, bool bRecieveLighting=false) override;
+        void RenderWorldQuad(const Vector3 *posList, const Vector2 *uvList, const Vector4 *color, bool bRecieveLighting=false) override;
 
         //Render States
-        virtual void EnableDepthWrite(bool bEnable) override;
-        virtual void EnableDepthRead(bool bEnable) override;
-        virtual void EnableStencilWriting(bool bEnable, uint32_t uValue) override;
-        virtual void EnableStencilTesting(bool bEnable) override;
-        virtual void EnableCulling(bool bEnable) override;
-        virtual void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128) override;
-        virtual void SetBlendMode(uint32_t uMode=BLEND_NONE) override;
-        virtual void EnableFog(bool bEnable, float fEnd=10000.0f) override;
-        virtual void SetFogDensity(float fDensity=1.0f) override;
+        void EnableDepthWrite(bool bEnable) override;
+        void EnableDepthRead(bool bEnable) override;
+        void EnableStencilWriting(bool bEnable, uint32_t uValue) override;
+        void EnableStencilTesting(bool bEnable) override;
+        void EnableCulling(bool bEnable) override;
+        void EnableAlphaTest(bool bEnable, uint8_t uAlphaCutoff=128) override;
+        void SetBlendMode(uint32_t uMode=BLEND_NONE) override;
+        void EnableFog(bool bEnable, float fEnd=10000.0f) override;
+        void SetFogDensity(float fDensity=1.0f) override;
 
         //Sorting
-        virtual bool ApplyOpaqueSort() override { return false; }
-        virtual bool ApplyTransSort() override { return false; }
+        bool ApplyOpaqueSort() override { return false; }
+        bool ApplyTransSort() override { return false; }
 
-        virtual Camera *GetCamera() override { return m_pRenderCamera; }
+        Camera *GetCamera() override { return m_pRenderCamera; }
 
         //Software Rendering specific.
         void SetBitDepth(int32_t bitDepth);
@@ -111,7 +111,7 @@ class Driver3D_Soft : public IDriver3D
         static Texture *GetCurTex() { return m_pCurTex; }
 
         //Driver extensions
-        virtual void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1) override;
+        void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1) override;
 
     protected:
 

--- a/render/IDriver3D.h
+++ b/render/IDriver3D.h
@@ -21,7 +21,7 @@ public:
         m_fLightAnim1 = s_fAnimOffset1; s_fAnimOffset1 += 32.0f*0.13f;
         m_fIntensity = 0.2f * (sinf(m_fLightAnim0)*0.5f+0.5f) + 0.1f * (sinf(m_fLightAnim1)*0.5f+0.5f) + 0.7f;
     }
-    ~LightObject() {};
+    ~LightObject() = default;
 
     void Update(float dt)
     {
@@ -102,7 +102,7 @@ class IDriver3D
         virtual void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) {};
         virtual void SetProjMtx(Matrix *pMtx) {};
         virtual void SetCamera(Camera *pCamera) {};
-        virtual Camera *GetCamera() {return 0;}
+        virtual Camera *GetCamera() {return nullptr;}
 
         virtual void ChangeWindowSize(int32_t w, int32_t h) {};
 

--- a/render/Mesh.h
+++ b/render/Mesh.h
@@ -13,8 +13,8 @@ public:
     Mesh();
     virtual ~Mesh();
 
-    virtual void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
-    virtual void GetBounds(Vector3& vMin, Vector3& vMax) override;
+    void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
+    void GetBounds(Vector3& vMin, Vector3& vMax) override;
 
     bool IsLoaded() { return m_bLoaded; }
     void SetLoaded() { m_bLoaded = true; }

--- a/render/Mesh.h
+++ b/render/Mesh.h
@@ -11,10 +11,10 @@ class Mesh : public RenderComponent
 {
 public:
     Mesh();
-    ~Mesh();
+    virtual ~Mesh();
 
-    void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset);
-    void GetBounds(Vector3& vMin, Vector3& vMax);
+    virtual void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
+    virtual void GetBounds(Vector3& vMin, Vector3& vMax) override;
 
     bool IsLoaded() { return m_bLoaded; }
     void SetLoaded() { m_bLoaded = true; }

--- a/render/linux/Driver3D_OGL_Linux.h
+++ b/render/linux/Driver3D_OGL_Linux.h
@@ -9,9 +9,9 @@ class Driver3D_OGL_Linux : public Driver3D_IPlatform
         Driver3D_OGL_Linux();
         virtual ~Driver3D_OGL_Linux();
 
-        virtual void SetWindowData(int32_t nParam, void **param) override;
+        void SetWindowData(int32_t nParam, void **param) override;
 
-        virtual void Present() override;
+        void Present() override;
     protected:
     private:
 };

--- a/render/linux/Driver3D_OGL_Linux.h
+++ b/render/linux/Driver3D_OGL_Linux.h
@@ -9,9 +9,9 @@ class Driver3D_OGL_Linux : public Driver3D_IPlatform
         Driver3D_OGL_Linux();
         virtual ~Driver3D_OGL_Linux();
 
-        void SetWindowData(int32_t nParam, void **param);
+        virtual void SetWindowData(int32_t nParam, void **param) override;
 
-        void Present();
+        virtual void Present() override;
     protected:
     private:
 };

--- a/render/win/Driver3D_OGL_Win.h
+++ b/render/win/Driver3D_OGL_Win.h
@@ -9,9 +9,9 @@ class Driver3D_OGL_Win : public Driver3D_IPlatform
         Driver3D_OGL_Win();
         virtual ~Driver3D_OGL_Win();
 
-        void SetWindowData(int32_t nParam, void **param);
+        virtual void SetWindowData(int32_t nParam, void **param) override;
 
-        void Present();
+        virtual void Present() override;
     protected:
     private:
 };

--- a/render/win/Driver3D_OGL_Win.h
+++ b/render/win/Driver3D_OGL_Win.h
@@ -9,9 +9,9 @@ class Driver3D_OGL_Win : public Driver3D_IPlatform
         Driver3D_OGL_Win();
         virtual ~Driver3D_OGL_Win();
 
-        virtual void SetWindowData(int32_t nParam, void **param) override;
+        void SetWindowData(int32_t nParam, void **param) override;
 
-        virtual void Present() override;
+        void Present() override;
     protected:
     private:
 };

--- a/world/CollisionComponent.h
+++ b/world/CollisionComponent.h
@@ -47,8 +47,8 @@ struct RaycastPacket
 class CollisionComponent
 {
 public:
-    CollisionComponent(){};
-    virtual ~CollisionComponent(){};
+    CollisionComponent() = default;
+    virtual ~CollisionComponent() = default;
 
     virtual bool Collide(CollisionPacket *packet, Matrix *pWorldMtx, const Vector3& vOffset) {return false; }
     virtual bool Raycast(RaycastPacket *packet, Matrix *pWorldMtx, Object *parent, Sector *pSector, const Vector3& vOffset) {return false;}

--- a/world/MeshCollision.h
+++ b/world/MeshCollision.h
@@ -15,8 +15,8 @@ public:
     MeshCollision();
     virtual ~MeshCollision();
 
-    virtual bool Collide(CollisionPacket *packet, Matrix *pWorldMtx, const Vector3& vOffset) override;
-    virtual bool Raycast(RaycastPacket *packet, Matrix *pWorldMtx, Object *parent, Sector *pSector, const Vector3& vOffset) override;
+    bool Collide(CollisionPacket *packet, Matrix *pWorldMtx, const Vector3& vOffset) override;
+    bool Raycast(RaycastPacket *packet, Matrix *pWorldMtx, Object *parent, Sector *pSector, const Vector3& vOffset) override;
     void TransformUpdateRequired() { m_pWorldMtx = 0; }
     void AddPolygon(int numVerts, Vector3 *pvVertices );
     void SetMaxPolygonCount(int maxPolyCount);

--- a/world/MeshCollision.h
+++ b/world/MeshCollision.h
@@ -13,10 +13,10 @@ class MeshCollision : public CollisionComponent
 {
 public:
     MeshCollision();
-    ~MeshCollision();
+    virtual ~MeshCollision();
 
-    bool Collide(CollisionPacket *packet, Matrix *pWorldMtx, const Vector3& vOffset);
-    bool Raycast(RaycastPacket *packet, Matrix *pWorldMtx, Object *parent, Sector *pSector, const Vector3& vOffset);
+    virtual bool Collide(CollisionPacket *packet, Matrix *pWorldMtx, const Vector3& vOffset) override;
+    virtual bool Raycast(RaycastPacket *packet, Matrix *pWorldMtx, Object *parent, Sector *pSector, const Vector3& vOffset) override;
     void TransformUpdateRequired() { m_pWorldMtx = 0; }
     void AddPolygon(int numVerts, Vector3 *pvVertices );
     void SetMaxPolygonCount(int maxPolyCount);

--- a/world/OrientedSprite.h
+++ b/world/OrientedSprite.h
@@ -11,14 +11,14 @@ class OrientedSprite : public RenderComponent
 {
 public:
     OrientedSprite();
-    virtual ~OrientedSprite(){};
+    virtual ~OrientedSprite() = default;
 
-    void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset);
-    void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
+    virtual void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
+    virtual void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) override { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
     void SetAlpha(float fAlpha=1.0f) { m_fAlpha = fAlpha; }
 
     //Oriented Sprite specific functions.
-    void SetTextureHandle(TextureHandle hTex) { m_hTex = hTex; }
+    virtual void SetTextureHandle(TextureHandle hTex) override { m_hTex = hTex; }
     void SetBaseIntensity(float fBaseItens) { m_fBaseItens = fBaseItens; }
 
 private:

--- a/world/OrientedSprite.h
+++ b/world/OrientedSprite.h
@@ -13,12 +13,12 @@ public:
     OrientedSprite();
     virtual ~OrientedSprite() = default;
 
-    virtual void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
-    virtual void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) override { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
+    void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
+    void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) override { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
     void SetAlpha(float fAlpha=1.0f) { m_fAlpha = fAlpha; }
 
     //Oriented Sprite specific functions.
-    virtual void SetTextureHandle(TextureHandle hTex) override { m_hTex = hTex; }
+    void SetTextureHandle(TextureHandle hTex) override { m_hTex = hTex; }
     void SetBaseIntensity(float fBaseItens) { m_fBaseItens = fBaseItens; }
 
 private:

--- a/world/RenderComponent.h
+++ b/world/RenderComponent.h
@@ -10,8 +10,8 @@ class Object;
 class RenderComponent
 {
 public:
-    RenderComponent(){};
-    virtual ~RenderComponent(){};
+    RenderComponent() = default;
+    virtual ~RenderComponent() = default;
 
     virtual void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) {};
     virtual void GetBounds(Vector3& vMin, Vector3& vMax) {};

--- a/world/Sector_2_5D.h
+++ b/world/Sector_2_5D.h
@@ -70,9 +70,9 @@ class Sector_2_5D : public Sector
 {
 public:
     Sector_2_5D();
-    ~Sector_2_5D();
+    virtual ~Sector_2_5D();
 
-    void Render(IDriver3D *pDriver, Camera *pCamera);
+    virtual void Render(IDriver3D *pDriver, Camera *pCamera) override;
     bool PointInsideSector(float x, float y);
     float GetZ_Floor(float x, float y, const std::vector<Sector *>& Sectors);
     float GetZ_Ceil(float x, float y, const std::vector<Sector *>& Sectors);

--- a/world/Sector_2_5D.h
+++ b/world/Sector_2_5D.h
@@ -72,7 +72,7 @@ public:
     Sector_2_5D();
     virtual ~Sector_2_5D();
 
-    virtual void Render(IDriver3D *pDriver, Camera *pCamera) override;
+    void Render(IDriver3D *pDriver, Camera *pCamera) override;
     bool PointInsideSector(float x, float y);
     float GetZ_Floor(float x, float y, const std::vector<Sector *>& Sectors);
     float GetZ_Ceil(float x, float y, const std::vector<Sector *>& Sectors);

--- a/world/Sector_GeoBlock.cpp
+++ b/world/Sector_GeoBlock.cpp
@@ -10,14 +10,6 @@
 
 #define MAX_WORLD_UPDATE_RANGE 30
 
-Sector_GeoBlock::Sector_GeoBlock() : Sector()
-{
-}
-
-Sector_GeoBlock::~Sector_GeoBlock()
-{
-}
-
 void Sector_GeoBlock::Render(IDriver3D *pDriver, Camera *pCamera)
 {
     if ( !m_bActive )

--- a/world/Sector_GeoBlock.cpp
+++ b/world/Sector_GeoBlock.cpp
@@ -10,6 +10,10 @@
 
 #define MAX_WORLD_UPDATE_RANGE 30
 
+Sector_GeoBlock::~Sector_GeoBlock()
+{
+}
+
 void Sector_GeoBlock::Render(IDriver3D *pDriver, Camera *pCamera)
 {
     if ( !m_bActive )

--- a/world/Sector_GeoBlock.h
+++ b/world/Sector_GeoBlock.h
@@ -19,13 +19,13 @@ class WorldCell;
 class Sector_GeoBlock : public Sector
 {
 public:
-    Sector_GeoBlock();
-    ~Sector_GeoBlock();
+    Sector_GeoBlock() = default;
+    virtual ~Sector_GeoBlock() = default;
 
-    void Render(IDriver3D *pDriver, Camera *pCamera);
-    void Collide(CollisionPacket *packet, Vector3 *bounds, const Vector3& vOffset);
-    void Raycast(RaycastPacket *packet, const Vector3& vOffset);
-    void Update(float dt);
+    virtual void Render(IDriver3D *pDriver, Camera *pCamera) override;
+    virtual void Collide(CollisionPacket *packet, Vector3 *bounds, const Vector3& vOffset) override;
+    virtual void Raycast(RaycastPacket *packet, const Vector3& vOffset) override;
+    virtual void Update(float dt) override;
 public:
 };
 

--- a/world/Sector_GeoBlock.h
+++ b/world/Sector_GeoBlock.h
@@ -20,12 +20,12 @@ class Sector_GeoBlock : public Sector
 {
 public:
     Sector_GeoBlock() = default;
-    virtual ~Sector_GeoBlock() = default;
+    virtual ~Sector_GeoBlock();
 
-    virtual void Render(IDriver3D *pDriver, Camera *pCamera) override;
-    virtual void Collide(CollisionPacket *packet, Vector3 *bounds, const Vector3& vOffset) override;
-    virtual void Raycast(RaycastPacket *packet, const Vector3& vOffset) override;
-    virtual void Update(float dt) override;
+    void Render(IDriver3D *pDriver, Camera *pCamera) override;
+    void Collide(CollisionPacket *packet, Vector3 *bounds, const Vector3& vOffset) override;
+    void Raycast(RaycastPacket *packet, const Vector3& vOffset) override;
+    void Update(float dt) override;
 public:
 };
 

--- a/world/Sprite_ZAxis.cpp
+++ b/world/Sprite_ZAxis.cpp
@@ -21,6 +21,10 @@ Sprite_ZAxis::Sprite_ZAxis() : RenderComponent()
     m_nFrameDelay = _FRAME_DELAY;
 }
 
+Sprite_ZAxis::~Sprite_ZAxis()
+{
+}
+
 void Sprite_ZAxis::Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset)
 {
     const Matrix& viewMtx = pDriver->GetRenderCam_ViewMtx();

--- a/world/Sprite_ZAxis.h
+++ b/world/Sprite_ZAxis.h
@@ -13,10 +13,10 @@ class Sprite_ZAxis : public RenderComponent
 {
 public:
     Sprite_ZAxis();
-    virtual ~Sprite_ZAxis() = default;
+    virtual ~Sprite_ZAxis();
 
-    virtual void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
-    virtual void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) override { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
+    void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
+    void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) override { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
     void SetAlpha(float fAlpha=1.0f) { m_fAlpha = fAlpha; }
     void AddFX_Frame(TextureHandle frameTex, uint32_t uWidth, uint32_t uHeight)
     {

--- a/world/Sprite_ZAxis.h
+++ b/world/Sprite_ZAxis.h
@@ -13,10 +13,10 @@ class Sprite_ZAxis : public RenderComponent
 {
 public:
     Sprite_ZAxis();
-    virtual ~Sprite_ZAxis(){};
+    virtual ~Sprite_ZAxis() = default;
 
-    void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset);
-    void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
+    virtual void Render(Object *pObj, IDriver3D *pDriver, float fIntensity, const Vector3& vOffset) override;
+    virtual void SetUV_Flip(bool bFlipX, bool bFlipY, bool bFlipAxis=false) override { m_aFlip[0] = bFlipX?1:0; m_aFlip[1] = bFlipY?1:0; m_aFlip[2] = bFlipAxis?1:0; }
     void SetAlpha(float fAlpha=1.0f) { m_fAlpha = fAlpha; }
     void AddFX_Frame(TextureHandle frameTex, uint32_t uWidth, uint32_t uHeight)
     {
@@ -28,7 +28,7 @@ public:
     }
 
     //Oriented Sprite specific functions.
-    void SetTextureHandle(TextureHandle hTex) { m_hTex = hTex; }
+    virtual void SetTextureHandle(TextureHandle hTex) override { m_hTex = hTex; }
     void SetBaseIntensity(float fBaseItens) { m_fBaseItens = fBaseItens; }
 
     void SetFlag(uint32_t uFlag) { m_uFlags |= uFlag; }

--- a/world/Sprite_ZAxis.h
+++ b/world/Sprite_ZAxis.h
@@ -28,7 +28,7 @@ public:
     }
 
     //Oriented Sprite specific functions.
-    virtual void SetTextureHandle(TextureHandle hTex) override { m_hTex = hTex; }
+    void SetTextureHandle(TextureHandle hTex) override { m_hTex = hTex; }
     void SetBaseIntensity(float fBaseItens) { m_fBaseItens = fBaseItens; }
 
     void SetFlag(uint32_t uFlag) { m_uFlags |= uFlag; }


### PR DESCRIPTION
As mentioned in the first commit's message, all the derived methods that have virtual base methods but don't call themselves virtual are still implicitly virtual, so adding `virtual` to them is optional (although that seems like a big mistake for the compiler to let it be optional).

`override` is also just a compile-time check, and there were no new errors from adding them, which means that all methods with `override` were indeed overriding a virtual base method already.

For empty constructors and destructors, I added `= default`, and I added `virtual` to base and derived destructors. I'm not sure if there's any point to adding `override` to virtual destructors.