### PR TITLE
Change iterator loops to range-based for loops

### DIFF
--- a/fileformats/CellLoader_Daggerfall.cpp
+++ b/fileformats/CellLoader_Daggerfall.cpp
@@ -703,11 +703,9 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
         {
             bool bValidNode = true;
             //is this point inside a mesh?
-            std::vector<uint32_t>::iterator iObj = pSector->m_Objects.begin();
-            std::vector<uint32_t>::iterator eObj = pSector->m_Objects.end();
-            for (; iObj != eObj; ++iObj)
+            for (const uint32_t objID : pSector->m_Objects)
             {
-                Object *pObj = ObjectManager::GetObjectFromID( *iObj );
+                Object *pObj = ObjectManager::GetObjectFromID(objID);
                 Vector3 vMin, vMax;
                 pObj->GetWorldBounds(vMin, vMax);
                 //is this node inside an object? If so, it is invalid...
@@ -1474,12 +1472,10 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
     }
 
     //now resolve action records.
-    std::vector<uint32_t>::iterator iObj = pSector->m_Objects.begin();
-    std::vector<uint32_t>::iterator eObj = pSector->m_Objects.end();
-    int idx=0;
-    for (; iObj != eObj; ++iObj)
+    int idx = 0;
+    for (const uint32_t objID : pSector->m_Objects)
     {
-        Object *pObj = ObjectManager::GetObjectFromID( *iObj );
+        Object *pObj = ObjectManager::GetObjectFromID(objID);
         assert(pObj);
 
         //resolve parent/child relationship.
@@ -1488,18 +1484,17 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
             MeshAction *pGameDataParent = (MeshAction *)pObj->GetGameData();
 
             int idxTarget = 0;
-            std::vector<uint32_t>::iterator iObjTarget = pSector->m_Objects.begin();
-            for (; iObjTarget != eObj; ++iObjTarget)
+            for (const uint32_t objTargetID : pSector->m_Objects)
             {
                 if ( objRecordID[idxTarget] == objTarget[idx] )
                 {
-                    Object *pObjTarget = ObjectManager::GetObjectFromID( *iObjTarget );
+                    Object *pObjTarget = ObjectManager::GetObjectFromID(objTargetID);
                     MeshAction *pGameDataTarget = (MeshAction *)pObjTarget->GetGameData();
 
                     if ( pGameDataTarget )
                     {
-                        pGameDataTarget->nParentID = *iObj;
-                        pGameDataParent->nTargetID = *iObjTarget;
+                        pGameDataTarget->nParentID = objID;
+                        pGameDataParent->nTargetID = objTargetID;
                     }
 
                     break;
@@ -1511,10 +1506,9 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
     }
 
     //Initialize the objects.
-    iObj = pSector->m_Objects.begin();
-    for (; iObj != eObj; ++iObj)
+    for (const uint32_t objID : pSector->m_Objects)
     {
-        Object *pObj = ObjectManager::GetObjectFromID( *iObj );
+        Object *pObj = ObjectManager::GetObjectFromID(objID);
         assert(pObj);
 
         //Finish the object initialization. Setup logics and such.
@@ -1578,10 +1572,9 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
 
     //assign lights to objects.
     const std::vector<LightObject *>& lightList = pSector->GetLightList();
-    iObj = pSector->m_Objects.begin();
-    for (; iObj != eObj; ++iObj)
+    for (const uint32_t objID : pSector->m_Objects)
     {
-        Object *pObj = ObjectManager::GetObjectFromID( *iObj );
+        Object *pObj = ObjectManager::GetObjectFromID(objID);
         assert(pObj);
 
         Vector3 vCen;

--- a/movieplayback/LFD_Film.cpp
+++ b/movieplayback/LFD_Film.cpp
@@ -579,12 +579,8 @@ bool LFD_Film::Update()
         {
             m_Commands[m_nTime].bActivated = true;
 
-            std::vector<Command *>::iterator iter = m_Commands[m_nTime].commands.begin();
-            std::vector<Command *>::iterator end  = m_Commands[m_nTime].commands.end();
-
-            for (; iter!=end; ++iter)
+            for (Command *pCmd : m_Commands[m_nTime].commands)
             {
-                Command *pCmd = *iter;
                 if ( pCmd->cmd == CMD_SWITCH )
                 {
                     Graphic *pGraphic = (Graphic *)pCmd->pData;
@@ -704,12 +700,8 @@ bool LFD_Film::Update()
         {
             if ( !bFilmFinished )
             {
-                std::vector<Graphic *>::iterator iter = m_Graphics.begin();
-                std::vector<Graphic *>::iterator end  = m_Graphics.end();
-                for (; iter!=end; ++iter)
+                for (Graphic *pGraphic : m_Graphics)
                 {
-                    Graphic *pGraphic = *iter;
-
                     if ( pGraphic->nAnimate > 0)
                     {
                         pGraphic->nFrame++;
@@ -968,12 +960,8 @@ void LFD_Film::Render(float fDeltaTime)
     }
 
     //render all the graphics that are visible...
-    std::vector<Graphic *>::iterator iter = m_Graphics.begin();
-    std::vector<Graphic *>::iterator end  = m_Graphics.end();
-    for (; iter!=end; ++iter)
+    for (Graphic *pGraphic : m_Graphics)
     {
-        Graphic *pGraphic = *iter;
-
         if ( pGraphic->bVisible )
         {
             AddGraphicToQueue(pGraphic, pGraphic->nLayer+100);

--- a/os/Input.cpp
+++ b/os/Input.cpp
@@ -61,12 +61,8 @@ void Input::SetKeyDown(int32_t key)
     key = s_OS_KeyMapping[key];
 
     //now fire off any callbacks...
-    std::vector<KeyDownCB_t *>::iterator iter = m_KeyDownCB.begin();
-    std::vector<KeyDownCB_t *>::iterator end  = m_KeyDownCB.end();
-    for (; iter != end; ++iter)
+    for (KeyDownCB_t *pKeyDownCB : m_KeyDownCB)
     {
-        KeyDownCB_t *pKeyDownCB = *iter;
-
         bool bFireCB = true;
         if ( (pKeyDownCB->nFlags&KDCb_FLAGS_NOREPEAT) && (m_aKeyState[key] != 0) )
              bFireCB = false;
@@ -95,11 +91,8 @@ void Input::SetCharacterDown(char c)
     if ( c >= 32 && c < 127 )
     {
         //fire off any "character" callbacks.
-        std::vector<KeyDownCB_t *>::iterator iter = m_CharDownCB.begin();
-        std::vector<KeyDownCB_t *>::iterator end  = m_CharDownCB.end();
-        for (; iter != end; ++iter)
+        for (KeyDownCB_t *pCharDownCB : m_CharDownCB)
         {
-            KeyDownCB_t *pCharDownCB = *iter;
             if ( pCharDownCB )
             {
                 pCharDownCB->pCB(c);

--- a/render/RenderQue.cpp
+++ b/render/RenderQue.cpp
@@ -130,12 +130,8 @@ void RenderQue::Render()
         m_pDriver->EnableCulling(true);
         m_pDriver->SetWorldMatrix(nullptr, 0, 0);
         //go through the list.
-        std::vector<MaterialEntry *>::iterator iEntry = m_apRenderBuckets[RBUCKET_OPAQUE].begin();
-        std::vector<MaterialEntry *>::iterator eEntry = m_apRenderBuckets[RBUCKET_OPAQUE].end();
-        for (; iEntry != eEntry; ++iEntry)
+        for (const MaterialEntry *pEntry : m_apRenderBuckets[RBUCKET_OPAQUE])
         {
-            const MaterialEntry *pEntry = *iEntry;
-
             //Set the world matrix.
             m_pDriver->SetWorldMatrix(pEntry->mWorld, pEntry->worldX, pEntry->worldY);
             //Set the texture.

--- a/ui/Console.cpp
+++ b/ui/Console.cpp
@@ -132,14 +132,13 @@ void Console::Print(const std::string& text)
 void Console::PrintCommandHelp(const std::string& cmd)
 {
     bool bCmdFound = false;
-    std::list<ConsoleItem>::const_iterator iter;
-    for (iter = m_ItemList.begin(); iter != m_ItemList.end(); ++iter)
+    for (const ConsoleItem &item : m_ItemList)
     {
-        if ( (*iter).name == cmd )
+        if ( item.name == cmd )
         {
             Print("^8---------------------------------------------------");
-            Print("^8" + (*iter).name + ": ");
-            Print("^2" + (*iter).help);
+            Print("^8" + item.name + ": ");
+            Print("^2" + item.help);
             Print("^8---------------------------------------------------");
             bCmdFound = true;
             break;
@@ -473,15 +472,14 @@ void Console::PrintCommands(const char *pszText/*=nullptr*/)
             l--;
     }
 
-    std::list<ConsoleItem>::const_iterator iter;
-    for (iter = m_ItemList.begin(); iter != m_ItemList.end(); ++iter)
+    for (const ConsoleItem &item : m_ItemList)
     {
         if ( pszText != nullptr && l > 0 )
         {
-            if ( strnicmp(pszText, (*iter).name.c_str(), l) != 0 )
+            if ( strnicmp(pszText, item.name.c_str(), l) != 0 )
                 continue;
         }
-        sprintf(szCmdText, "^7%s", (*iter).name.c_str());
+        sprintf(szCmdText, "^7%s", item.name.c_str());
         Print(szCmdText);
     }
 }
@@ -491,7 +489,6 @@ bool Console::ParseCommandLine()
     std::ostringstream out;
     std::string::size_type index = 0;
     std::vector<std::string> arguments;
-    std::list<ConsoleItem>::const_iterator iter;
 
     //add to text buffer - command echo.
     if ( m_bEchoCommands )
@@ -534,23 +531,23 @@ bool Console::ParseCommandLine()
     }
 
     //execute (must look for a command or variable).
-    for (iter = m_ItemList.begin(); iter != m_ItemList.end(); ++iter)
+    for (const ConsoleItem &item : m_ItemList)
     {
-        if ( iter->name == arguments[0] )
+        if ( item.name == arguments[0] )
         {
-            switch (iter->type)
+            switch (item.type)
             {
                 case CTYPE_UCHAR:
                     if ( arguments.size() > 2) return false;
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << *((unsigned char *)(*iter).varPtr);
+                        out << item.name << " = " << *((unsigned char *)item.varPtr);
                         Print(out.str());
                     }
                     else
                     {
-                        *((unsigned char *)(*iter).varPtr) = (unsigned char)atoi(arguments[1].c_str());
+                        *((unsigned char *)item.varPtr) = (unsigned char)atoi(arguments[1].c_str());
                     }
                     return true;
                     break;
@@ -559,12 +556,12 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << *((char *)(*iter).varPtr);
+                        out << item.name << " = " << *((char *)item.varPtr);
                         Print(out.str());
                     }
                     else
                     {
-                        *((char *)(*iter).varPtr) = (char)atoi(arguments[1].c_str());
+                        *((char *)item.varPtr) = (char)atoi(arguments[1].c_str());
                     }
                     return true;
                     break;
@@ -573,12 +570,12 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << *((uint32_t *)(*iter).varPtr);
+                        out << item.name << " = " << *((uint32_t *)item.varPtr);
                         Print(out.str());
                     }
                     else
                     {
-                        *((uint32_t *)(*iter).varPtr) = (uint32_t)atoi(arguments[1].c_str());
+                        *((uint32_t *)item.varPtr) = (uint32_t)atoi(arguments[1].c_str());
                     }
                     return true;
                     break;
@@ -587,12 +584,12 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << *((int32_t *)(*iter).varPtr);
+                        out << item.name << " = " << *((int32_t *)item.varPtr);
                         Print(out.str());
                     }
                     else
                     {
-                        *((int32_t *)(*iter).varPtr) = (int32_t)atoi(arguments[1].c_str());
+                        *((int32_t *)item.varPtr) = (int32_t)atoi(arguments[1].c_str());
                     }
                     return true;
                     break;
@@ -601,12 +598,12 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << *((float *)(*iter).varPtr);
+                        out << item.name << " = " << *((float *)item.varPtr);
                         Print(out.str());
                     }
                     else
                     {
-                        *((float *)(*iter).varPtr) = (float)atof(arguments[1].c_str());
+                        *((float *)item.varPtr) = (float)atof(arguments[1].c_str());
                     }
                     return true;
                     break;
@@ -615,12 +612,12 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << ( *((bool *)(*iter).varPtr) ? "1" : "0" );
+                        out << item.name << " = " << ( *((bool *)item.varPtr) ? "1" : "0" );
                         Print(out.str());
                     }
                     else
                     {
-                        *((bool *)(*iter).varPtr) = atoi(arguments[1].c_str()) ? true : false;
+                        *((bool *)item.varPtr) = atoi(arguments[1].c_str()) ? true : false;
                     }
                     return true;
                     break;
@@ -629,12 +626,12 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << *((std::string *)(*iter).varPtr);
+                        out << item.name << " = " << *((std::string *)item.varPtr);
                         Print(out.str());
                     }
                     else
                     {
-                        *((std::string *)(*iter).varPtr) = arguments[1];
+                        *((std::string *)item.varPtr) = arguments[1];
                     }
                     return true;
                     break;
@@ -643,12 +640,12 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() == 1)
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << std::string((char *)(*iter).varPtr);
+                        out << item.name << " = " << std::string((char *)item.varPtr);
                         Print(out.str());
                     }
                     else
                     {
-                        strcpy((char *)(*iter).varPtr, arguments[1].c_str());
+                        strcpy((char *)item.varPtr, arguments[1].c_str());
                     }
                     return true;
                     break;
@@ -657,15 +654,15 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() != 4 )
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << ((Vector3 *)(*iter).varPtr)->x << " " << ((Vector3 *)(*iter).varPtr)->y << " " <<
-                            ((Vector3 *)(*iter).varPtr)->z;
+                        out << item.name << " = " << ((Vector3 *)item.varPtr)->x << " " << ((Vector3 *)item.varPtr)->y << " " <<
+                            ((Vector3 *)item.varPtr)->z;
                         Print(out.str());
                     }
                     else
                     {
-                        ((Vector3 *)(*iter).varPtr)->x = (float)atof(arguments[1].c_str());
-                        ((Vector3 *)(*iter).varPtr)->y = (float)atof(arguments[2].c_str());
-                        ((Vector3 *)(*iter).varPtr)->z = (float)atof(arguments[3].c_str());
+                        ((Vector3 *)item.varPtr)->x = (float)atof(arguments[1].c_str());
+                        ((Vector3 *)item.varPtr)->y = (float)atof(arguments[2].c_str());
+                        ((Vector3 *)item.varPtr)->z = (float)atof(arguments[3].c_str());
                     }
                     return true;
                     break;
@@ -674,21 +671,21 @@ bool Console::ParseCommandLine()
                     else if ( arguments.size() != 5 )
                     {
                         out.str("");    //clear stringstream
-                        out << (*iter).name << " = " << ((Vector4 *)(*iter).varPtr)->x << " " << ((Vector4 *)(*iter).varPtr)->y << " " <<
-                            ((Vector4 *)(*iter).varPtr)->z << " " << ((Vector4 *)(*iter).varPtr)->w;
+                        out << item.name << " = " << ((Vector4 *)item.varPtr)->x << " " << ((Vector4 *)item.varPtr)->y << " " <<
+                            ((Vector4 *)item.varPtr)->z << " " << ((Vector4 *)item.varPtr)->w;
                         Print(out.str());
                     }
                     else
                     {
-                        ((Vector4 *)(*iter).varPtr)->x = (float)atof(arguments[1].c_str());
-                        ((Vector4 *)(*iter).varPtr)->y = (float)atof(arguments[2].c_str());
-                        ((Vector4 *)(*iter).varPtr)->z = (float)atof(arguments[3].c_str());
-                        ((Vector4 *)(*iter).varPtr)->w = (float)atof(arguments[4].c_str());
+                        ((Vector4 *)item.varPtr)->x = (float)atof(arguments[1].c_str());
+                        ((Vector4 *)item.varPtr)->y = (float)atof(arguments[2].c_str());
+                        ((Vector4 *)item.varPtr)->z = (float)atof(arguments[3].c_str());
+                        ((Vector4 *)item.varPtr)->w = (float)atof(arguments[4].c_str());
                     }
                     return true;
                     break;
                 case CTYPE_FUNCTION:
-                    (*iter).func(arguments, (*iter).userData);
+                    item.func(arguments, item.userData);
                     return true;
                     break;
                 default:

--- a/ui/UI_System.cpp
+++ b/ui/UI_System.cpp
@@ -507,11 +507,8 @@ void UI_System::UI_PopWindow()
 
 void UI_System::UI_EnableWindow(std::string& sName, int enable)
 {
-    std::vector<UI_Window *>::iterator iWindow = m_WindowList.begin();
-    std::vector<UI_Window *>::iterator eWindow = m_WindowList.end();
-    for (; iWindow != eWindow; ++iWindow)
+    for (UI_Window *pWindow : m_WindowList)
     {
-        UI_Window *pWindow = *iWindow;
         if ( pWindow->m_name == sName )
         {
             pWindow->m_bEnabled = enable ? true : false;

--- a/world/LevelFuncMgr.cpp
+++ b/world/LevelFuncMgr.cpp
@@ -99,21 +99,17 @@ void LevelFuncMgr::RemoveFromActiveList(LevelFunc *pFunc)
 
 void LevelFuncMgr::Update()
 {
-    std::vector<LevelFunc *>::iterator iActive = m_Active.begin();
-    std::vector<LevelFunc *>::iterator eActive = m_Active.end();
-    for (; iActive!=eActive; ++iActive)
+    for (LevelFunc *activeFunc : m_Active)
     {
-        if (*iActive) { (*iActive)->Update(); }
+        if (activeFunc) { activeFunc->Update(); }
     }
 
     //go through the add list and add classes...
     if ( m_AddList.size() )
     {
-        std::vector<LevelFunc *>::iterator iAdd = m_AddList.begin();
-        std::vector<LevelFunc *>::iterator eAdd = m_AddList.end();
-        for (; iAdd!=eAdd; ++iAdd)
+        for (LevelFunc *addFunc : m_AddList)
         {
-            if (*iAdd) { m_Active.push_back( *iAdd ); }
+            if (addFunc) { m_Active.push_back(addFunc); }
         }
         m_AddList.clear();
     }
@@ -121,16 +117,14 @@ void LevelFuncMgr::Update()
     //go through the remove list and remove classes...
     if ( m_RemoveList.size() )
     {
-        std::vector<LevelFunc *>::iterator iRem = m_RemoveList.begin();
-        std::vector<LevelFunc *>::iterator eRem = m_RemoveList.end();
-        for (; iRem!=eRem; ++iRem)
+        for (LevelFunc *remFunc : m_RemoveList)
         {
-            iActive = m_Active.begin();
-            eActive = m_Active.end();
+            std::vector<LevelFunc *>::iterator iActive = m_Active.begin();
+            std::vector<LevelFunc *>::iterator eActive = m_Active.end();
 
             for (; iActive!=eActive; ++iActive)
             {
-                if ( *iActive == *iRem )
+                if ( *iActive == remFunc )
                 {
                     m_Active.erase(iActive);
                     break;

--- a/world/Object.cpp
+++ b/world/Object.cpp
@@ -94,23 +94,17 @@ void Object::AddLogic(Logic *pLogic)
 //initialize the object
 void Object::Init()
 {
-    std::vector<Logic *>::iterator iLogic = m_Logics.begin();
-    std::vector<Logic *>::iterator eLogic = m_Logics.end();
-
-    for (; iLogic != eLogic; ++iLogic)
+    for (Logic *logic : m_Logics)
     {
-        (*iLogic)->InitObject(this);
+        logic->InitObject(this);
     }
 }
 
 void Object::SendMessage(uint32_t uMsgID, float fValue)
 {
-    std::vector<Logic *>::iterator iLogic = m_Logics.begin();
-    std::vector<Logic *>::iterator eLogic = m_Logics.end();
-
-    for (; iLogic != eLogic; ++iLogic)
+    for (Logic *logic : m_Logics)
     {
-        (*iLogic)->SendMessage(this, uMsgID, fValue);
+        logic->SendMessage(this, uMsgID, fValue);
     }
 }
 
@@ -118,12 +112,9 @@ void Object::Update()
 {
     if ( m_uFlags&OBJFLAGS_ACTIVE )
     {
-        std::vector<Logic *>::iterator iLogic = m_Logics.begin();
-        std::vector<Logic *>::iterator eLogic = m_Logics.end();
-
-        for (; iLogic != eLogic; ++iLogic)
+        for (Logic *logic : m_Logics)
         {
-            (*iLogic)->Update(this);
+            logic->Update(this);
         }
     }
 }

--- a/world/ObjectManager.cpp
+++ b/world/ObjectManager.cpp
@@ -5,6 +5,8 @@
 #include "../world/World.h"
 #include "../world/Terrain.h"
 
+#include <algorithm>
+
 std::vector<Object *> ObjectManager::m_ObjectPool;
 std::vector<Object *> ObjectManager::m_FreeObjects;
 std::vector<Object *> ObjectManager::m_ActiveObjects;
@@ -176,11 +178,8 @@ uint32_t ObjectManager::CreateObjectID(const char *pszName, int32_t nSector)
 
 void ObjectManager::MoveDynamicObjects(const Vector3& vMove)
 {
-    std::vector<Object *>::iterator iObj = m_ActiveObjects.begin();
-    std::vector<Object *>::iterator eObj = m_ActiveObjects.end();
-    for (; iObj != eObj; ++iObj)
+    for (Object *pObj : m_ActiveObjects)
     {
-        Object *pObj = *iObj;
         if ( pObj->IsFlagSet( Object::OBJFLAGS_DYNAMIC ) )
         {
             //Update the object location.
@@ -207,17 +206,13 @@ void ObjectManager::MoveDynamicObjects(const Vector3& vMove)
 
 Object *ObjectManager::FindObject(const std::string& sName)
 {
-    std::vector<Object *>::iterator iObj = m_ActiveObjects.begin();
-    std::vector<Object *>::iterator eObj = m_ActiveObjects.end();
-    for (; iObj != eObj; ++iObj)
+    const auto iter = std::find_if(m_ActiveObjects.begin(), m_ActiveObjects.end(),
+        [&sName](Object *pObj)
     {
-        Object *pObj = *iObj;
-        if ( pObj->GetName() == sName )
-        {
-            return pObj;
-        }
-    }
-    return nullptr;
+        return pObj->GetName() == sName;
+    });
+
+    return (iter != m_ActiveObjects.end()) ? *iter : nullptr;
 }
 
 Object *ObjectManager::GetObjectFromID(uint32_t uID)
@@ -262,11 +257,8 @@ void ObjectManager::FreeAllObjects()
 {
     m_FreeObjects.clear();
     uint32_t uStartObj = m_uReservedCount;
-    std::vector<Object *>::iterator iBank = m_ObjectPool.begin();
-    std::vector<Object *>::iterator eBank = m_ObjectPool.end();
-    for (; iBank != eBank; ++iBank)
+    for (Object *pool : m_ObjectPool)
     {
-        Object *pool = *iBank;
         for (uint32_t i=uStartObj; i<OBJCOUNT_PER_BANK; i++)
         {
             pool[i].Reset();
@@ -286,11 +278,9 @@ void ObjectManager::FreeAllObjects()
 
 void ObjectManager::Update()
 {
-    std::vector<Object *>::iterator iObj = m_ActiveObjects.begin();
-    std::vector<Object *>::iterator eObj = m_ActiveObjects.end();
-    for (; iObj != eObj; ++iObj)
+    for (Object *obj : m_ActiveObjects)
     {
-        (*iObj)->Update();
+        obj->Update();
     }
 }
 

--- a/world/Sector_2_5D.cpp
+++ b/world/Sector_2_5D.cpp
@@ -2024,11 +2024,8 @@ void Sector_2_5D::Visibility2D(const Vector3& cPos, Vector2 fL, Vector2 fR, uint
     fI = fOO255 * (float)shade;
 
     //now add objects to the list...
-    std::vector<uint32_t>::iterator iObj = pCurSec->m_Objects.begin();
-    std::vector<uint32_t>::iterator eObj = pCurSec->m_Objects.end();
-    for (; iObj != eObj; ++iObj)
+    for (const uint32_t uObjID : pCurSec->m_Objects)
     {
-        uint32_t uObjID = *iObj;
         Object *pObj = ObjectManager::GetObjectFromID(uObjID);
         if ( pObj->GetRenderKey() != _uRenderKey )
         {

--- a/world/Sector_GeoBlock.cpp
+++ b/world/Sector_GeoBlock.cpp
@@ -19,11 +19,9 @@ void Sector_GeoBlock::Render(IDriver3D *pDriver, Camera *pCamera)
     if ( !m_bActive )
         return;
 
-    std::vector<uint32_t>::iterator iObj = m_Objects.begin();
-    std::vector<uint32_t>::iterator eObj = m_Objects.end();
-    for (; iObj != eObj; ++iObj)
+    for (const uint32_t objID : m_Objects)
     {
-        Object *pObj = ObjectManager::GetObjectFromID( *iObj );
+        Object *pObj = ObjectManager::GetObjectFromID(objID);
         assert(pObj);
 
         Vector3 vMin, vMax;
@@ -44,12 +42,10 @@ void Sector_GeoBlock::Collide(CollisionPacket *packet, Vector3 *bounds, const Ve
 {
     if ( !m_bActive )
         return;
-
-    std::vector<uint32_t>::iterator iObj = m_Objects.begin();
-    std::vector<uint32_t>::iterator eObj = m_Objects.end();
-    for (; iObj != eObj; ++iObj)
+    
+    for (const uint32_t objID : m_Objects)
     {
-        Object *pObj = ObjectManager::GetObjectFromID( *iObj );
+        Object *pObj = ObjectManager::GetObjectFromID(objID);
         assert(pObj);
 
         Vector3 vMin = pObj->GetWorldMin() + vOffset;
@@ -66,11 +62,9 @@ void Sector_GeoBlock::Raycast(RaycastPacket *packet, const Vector3& vOffset)
     if ( !m_bActive )
         return;
 
-    std::vector<uint32_t>::iterator iObj = m_Objects.begin();
-    std::vector<uint32_t>::iterator eObj = m_Objects.end();
-    for (; iObj != eObj; ++iObj)
+    for (const uint32_t objID : m_Objects)
     {
-        Object *pObj = ObjectManager::GetObjectFromID( *iObj );
+        Object *pObj = ObjectManager::GetObjectFromID(objID);
         assert(pObj);
 
         Vector3 vMin = pObj->GetWorldMin() + vOffset;
@@ -87,10 +81,8 @@ void Sector_GeoBlock::Update(float dt)
     if ( !m_bActive )
         return;
 
-    std::vector<LightObject *>::iterator iLight = m_Lights.begin();
-    std::vector<LightObject *>::iterator eLight = m_Lights.end();
-    for (; iLight != eLight; ++iLight)
+    for (LightObject *light : m_Lights)
     {
-        (*iLight)->Update( dt );
+        light->Update( dt );
     }
 }

--- a/world/World.cpp
+++ b/world/World.cpp
@@ -74,11 +74,8 @@ void World::Collide(Vector3 *p0, Vector3 *p1, uint32_t& uSector, float fRadius, 
         int32_t camY = m_pCamera->GetWorldPosY()>>3;
         int32_t cx, cy;
 
-        std::vector<WorldCell *>::iterator iCell = m_WorldCells.begin();
-        std::vector<WorldCell *>::iterator eCell = m_WorldCells.end();
-        for (; iCell != eCell; ++iCell)
+        for (WorldCell *pCell : m_WorldCells)
         {
-            WorldCell *pCell = *iCell;
             pCell->GetWorldPos(cx, cy);
 
             //only try to collide if in the same world cell or neighboring cell.
@@ -119,11 +116,8 @@ void World::RayCastAndActivate(Vector3 *p0, Vector3 *p1, uint32_t& uSector)
         int32_t camY = m_pCamera->GetWorldPosY()>>3;
         int32_t cx, cy;
 
-        std::vector<WorldCell *>::iterator iCell = m_WorldCells.begin();
-        std::vector<WorldCell *>::iterator eCell = m_WorldCells.end();
-        for (; iCell != eCell; ++iCell)
+        for (WorldCell *pCell : m_WorldCells)
         {
-            WorldCell *pCell = *iCell;
             pCell->GetWorldPos(cx, cy);
 
             //only try to collide if in the same world cell or neighboring cell.
@@ -148,11 +142,8 @@ bool World::Raycast(Vector3 *p0, Vector3 *p1, Vector3 *pInter)
             int32_t camY = m_pCamera->GetWorldPosY()>>3;
             int32_t cx, cy;
 
-            std::vector<WorldCell *>::iterator iCell = m_WorldCells.begin();
-            std::vector<WorldCell *>::iterator eCell = m_WorldCells.end();
-            for (; iCell != eCell; ++iCell)
+            for (WorldCell *pCell : m_WorldCells)
             {
-                WorldCell *pCell = *iCell;
                 pCell->GetWorldPos(cx, cy);
 
                 //only try to collide if in the same world cell or neighboring cell.
@@ -198,12 +189,10 @@ bool World::Update(float dt, IDriver3D *pDriver)
     if ( !player || !m_pCamera )
         return false;
 
-    std::vector<WorldCell *>::iterator iCell = m_WorldCells.begin();
-    std::vector<WorldCell *>::iterator eCell = m_WorldCells.end();
-    for (; iCell != eCell; ++iCell)
+    for (WorldCell *pCell : m_WorldCells)
     {
         //add culling, won't affect games that only have a single cell..
-        (*iCell)->Update( m_pCamera, dt, m_uSectorTypeVis );
+        pCell->Update( m_pCamera, dt, m_uSectorTypeVis );
     }
     if ( (m_uSectorTypeVis&SECTOR_TYPE_EXTERIOR) && m_pTerrain )
     {
@@ -461,12 +450,10 @@ void World::Render(IDriver3D *pDriver)
         m_pTerrain->Render( m_pCamera );
     }
 
-    std::vector<WorldCell *>::iterator iCell = m_WorldCells.begin();
-    std::vector<WorldCell *>::iterator eCell = m_WorldCells.end();
-    for (; iCell != eCell; ++iCell)
+    for (WorldCell *pCell : m_WorldCells)
     {
         //add culling, won't affect games that only have a single cell..
-        (*iCell)->Render( pDriver, m_pCamera, m_uSectorTypeVis );
+        pCell->Render( pDriver, m_pCamera, m_uSectorTypeVis );
     }
 }
 
@@ -483,11 +470,9 @@ void World::CC_LockCamera(const std::vector<std::string>& args, void *pUserData)
     }
 
     Camera::EnableCameraUpdating( !bLock );
-    std::vector<WorldCell *>::iterator iCell = pThis->m_WorldCells.begin();
-    std::vector<WorldCell *>::iterator eCell = pThis->m_WorldCells.end();
-    for (; iCell != eCell; ++iCell)
+    for (WorldCell *pCell : pThis->m_WorldCells)
     {
         //add culling, won't affect games that only have a single cell..
-        (*iCell)->LockCamera( pThis->m_pCamera, bLock );
+        pCell->LockCamera( pThis->m_pCamera, bLock );
     }
 }


### PR DESCRIPTION
I didn't touch any iterator loops that `erase()` elements because I couldn't think of a cleaner way to do it (`vec.erase(std::remove_if(...), vec.end())` wasn't an option for most of those because they break on the first found element, so I couldn't guarantee identical behavior).