### PR TITLE
Copy required files to the build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,16 @@ elseif(NOT WIN32)
     set_target_properties(XLEngine PROPERTIES INSTALL_RPATH "$ORIGIN")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
+
+# Copy required resources to the build directory
+add_custom_command(
+    TARGET XLEngine POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${XLEngine_SOURCE_DIR}/XLEngine.conf $<TARGET_FILE_DIR:XLEngine>/
+    COMMAND ${CMAKE_COMMAND} -E copy_directory    ${XLEngine_SOURCE_DIR}/resources     $<TARGET_FILE_DIR:XLEngine>/
+    COMMENT "Copy required resources to the build directory"
+    VERBATIM
+)
+
 # XL Engine shared library sources.
 set(bloodxl_sources
     ${src_root}/BloodXL/BloodXL_Game.h

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ## TODO
 * game plugin fix-ups
-* have cmake place images, as and other things into the build directory
 
 ## Dependencies
 * DevIL Cross-platform image loading and manipulation toolkit

--- a/XLEngine.conf
+++ b/XLEngine.conf
@@ -1,0 +1,19 @@
+[general]
+width = 1280 # window/screen width, 320 minimum
+height = 720 # window/screen height, 200 minimum
+fullscreen = false # true or false
+vsync = false # true or false
+emulate-low-res = false # true to render at 320x200 and stretch to fit, or false
+renderer =  opengl # opengl, soft32 (true-color software), soft8 (paletted software)
+
+[DaggerXL]
+data-path = # Full path to game data, e.g. C:\DAGGER\ARENA2
+
+[DarkXL]
+data-path = # ...
+
+[BloodXL]
+data-path = # ...
+
+[OutlawsXL]
+data-path = # ...


### PR DESCRIPTION
Cmake will now copy the required files to the build directory after the build has finished

**Note:** I haven't tested this yet, because I haven't been able to get the XLEngine up and running