### PR TITLE
Add more unit vector members.

### DIFF
--- a/DaggerXL/DaggerXL_Player.cpp
+++ b/DaggerXL/DaggerXL_Player.cpp
@@ -298,7 +298,7 @@ void DaggerXL_Player::Update(uint32_t uObjID, uint32_t uParamCount, LogicParam *
     }
     //do a single raycast to make sure the player hasn't sunk into the ground...
     Vector3 vStart, vEnd, vInter;
-    vStart = vLoc + Vector3(0.0f, 0.0f, 0.0f);
+    vStart = vLoc;
     vEnd = vStart - Vector3(0.0f, 0.0f, 8.9f);
     if ( m_pAPI->World_Raycast(&vStart, &vEnd, &vInter) )
     {

--- a/Engine.cpp
+++ b/Engine.cpp
@@ -261,11 +261,8 @@ bool Engine::Init(void **winParam, int32_t paramCnt, int32_t w, int32_t h)
                 Matrix projMtx;
                 projMtx.ProjOrtho((float)m_nWidth, (float)m_nHeight);
 
-                Vector3 pLoc = Vector3(0,0,0);
-                Vector3 pDir = Vector3(0,0,1);
-
                 m_pDriver3D->SetProjMtx( &projMtx );
-                m_pDriver3D->SetViewMatrix( &Matrix::s_Identity, &pLoc, &pDir);
+                m_pDriver3D->SetViewMatrix( &Matrix::s_Identity, &Vector3::Zero, &Vector3::UnitZ);
                 m_pDriver3D->SetWorldMatrix( &Matrix::s_Identity, 0, 0 );
 
                 //now only wait so long...
@@ -841,11 +838,8 @@ bool Engine::Loop(float fDeltaTime, bool bFullspeed)
             Matrix projMtx;
             projMtx.ProjOrtho((float)m_nWidth, (float)m_nHeight);
 
-            Vector3 pDir = Vector3(0,0,0);
-            Vector3 pLoc = Vector3(0,0,1);
-
             m_pDriver3D->SetProjMtx( &projMtx );
-            m_pDriver3D->SetViewMatrix( &Matrix::s_Identity, &pDir, &pLoc );
+            m_pDriver3D->SetViewMatrix( &Matrix::s_Identity, &Vector3::Zero, &Vector3::UnitZ);
             m_pDriver3D->SetWorldMatrix( &Matrix::s_Identity, 0, 0 );
 
             //call game PostWorld Render (usually UI).

--- a/fileformats/CellLoader_BloodMap.cpp
+++ b/fileformats/CellLoader_BloodMap.cpp
@@ -979,7 +979,7 @@ WorldCell *CellLoader_BloodMap::Load( IDriver3D *pDriver, World *pWorld, uint8_t
                         vLoc.y = -(float)m_pBloodSprites[i].y / fHorizScale;
                         vLoc.z = -(float)m_pBloodSprites[i].z / fVertScale;
 
-                        Vector3 vDir = Vector3(0, 0, 1);
+                        Vector3 vDir = Vector3::UnitZ;
 
                         float yaw = (float)m_pBloodSprites[i].ang/2048.0f * MATH_TWO_PI + MATH_PI;
                         Vector3 vUp;

--- a/fileformats/CellLoader_Daggerfall.cpp
+++ b/fileformats/CellLoader_Daggerfall.cpp
@@ -448,7 +448,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
 
             Object *pMeshObj = ObjectManager::CreateObject("exterior");
             pMeshObj->SetWorldPos(worldX, worldY);
-            pMeshObj->SetScale( Vector3(1,1,1) );
+            pMeshObj->SetScale( Vector3::One );
             pSector->AddObject( pMeshObj->GetID() );
             
             Vector3 vPos;
@@ -461,7 +461,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
             Matrix mBlockRot;
             float zAngle = -(float)pBlockPos[j].Angle * MATH_PI_OVER_2/512.0f;
             mBlockRot.Identity();
-            Vector3 vAngel = Vector3(0, 0, 1);
+            Vector3 vAngel = Vector3::UnitZ;
             mBlockRot.AxisAngle( vAngel , zAngle );
             Vector3 vBlockOffs = Vector3((float)pBlockPos[j].XPos2 * fFP_Scale, (float)pBlockPos[j].YPos2 * fFP_Scale, 0.0f);
             Vector3 vOutPos = mBlockRot.TransformVector(vPos);
@@ -640,7 +640,7 @@ Sector *CellLoader_Daggerfall::LoadBlock_Ext(IDriver3D *pDriver, uint32_t uLengt
 
         Object *pMeshObj = ObjectManager::CreateObject("exterior");
         pMeshObj->SetWorldPos(worldX, worldY);
-        pMeshObj->SetScale( Vector3(1,1,1) );
+        pMeshObj->SetScale( Vector3::One );
         pSector->AddObject( pMeshObj->GetID() );
 
         Vector3 vPos;
@@ -1072,7 +1072,7 @@ Sector *CellLoader_Daggerfall::LoadBlock(IDriver3D *pDriver, uint32_t uLength, i
                     //pMeshObj->nLightCnt = 0;
                     //pMeshObj->nFactionID = 0;
 
-                    pMeshObj->SetScale( Vector3(1,1,1) );
+                    pMeshObj->SetScale( Vector3::One );
 
                     Vector3 vPos;
                     vPos.x =  (float)object.xLoc * fFP_Scale + vBlockLoc.x;

--- a/math/Matrix.cpp
+++ b/math/Matrix.cpp
@@ -103,9 +103,9 @@ void Matrix::AxisAngle(Vector3& axis, float angle)
 
 void Matrix::EulerToMatrix(float yaw, float pitch, float roll)
 {
-    Vector3 vPitch = Vector3(1,0,0);
-    Vector3 vYaw = Vector3(0,1,0);
-    Vector3 vRoll = Vector3(0,0,1);
+    Vector3 vPitch = Vector3::UnitX;
+    Vector3 vYaw = Vector3::UnitY;
+    Vector3 vRoll = Vector3::UnitZ;
     this->AxisAngle( vPitch, -pitch );
     this->AxisAngle( vYaw,  yaw );
     this->AxisAngle( vRoll,  roll );

--- a/math/Vector2.cpp
+++ b/math/Vector2.cpp
@@ -1,9 +1,10 @@
 #include "Vector2.h"
-#include <cmath>
 
-Vector2 Vector2::One(1.0f, 1.0f);
-Vector2 Vector2::Half(0.5f, 0.5f);
-Vector2 Vector2::Zero(0.0f, 0.0f);
+const Vector2 Vector2::One(1.0f, 1.0f);
+const Vector2 Vector2::Half(0.5f, 0.5f);
+const Vector2 Vector2::Zero(0.0f, 0.0f);
+const Vector2 Vector2::UnitX(1.0f, 0.0f);
+const Vector2 Vector2::UnitY(0.0f, 1.0f);
 
 float Vector2::Normalize()
 {

--- a/math/Vector2.h
+++ b/math/Vector2.h
@@ -24,7 +24,7 @@ class Vector2
 public:
     Vector2() { x = 0.0f; y = 0.0f; }
     Vector2(float _x, float _y) { x = _x; y = _y; }
-	~Vector2() = default;
+    ~Vector2() = default;
 
     float Normalize();
     float Length()

--- a/math/Vector2.h
+++ b/math/Vector2.h
@@ -24,7 +24,7 @@ class Vector2
 public:
     Vector2() { x = 0.0f; y = 0.0f; }
     Vector2(float _x, float _y) { x = _x; y = _y; }
-    ~Vector2() {;}
+	~Vector2() = default;
 
     float Normalize();
     float Length()
@@ -96,9 +96,11 @@ public:
 
     float x, y;
 
-    static Vector2 One;
-    static Vector2 Half;
-    static Vector2 Zero;
+    static const Vector2 One;
+    static const Vector2 Half;
+    static const Vector2 Zero;
+    static const Vector2 UnitX;
+    static const Vector2 UnitY;
 };
 
 #endif //VECTOR2_H

--- a/math/Vector3.cpp
+++ b/math/Vector3.cpp
@@ -1,6 +1,8 @@
 #include "Vector3.h"
-#include <cmath>
 
-Vector3 Vector3::One(1.0f, 1.0f, 1.0f);
-Vector3 Vector3::Half(0.5f, 0.5f, 0.5f);
-Vector3 Vector3::Zero(0.0f, 0.0f, 0.0f);
+const Vector3 Vector3::One(1.0f, 1.0f, 1.0f);
+const Vector3 Vector3::Half(0.5f, 0.5f, 0.5f);
+const Vector3 Vector3::Zero(0.0f, 0.0f, 0.0f);
+const Vector3 Vector3::UnitX(1.0f, 0.0f, 0.0f);
+const Vector3 Vector3::UnitY(0.0f, 1.0f, 0.0f);
+const Vector3 Vector3::UnitZ(0.0f, 0.0f, 1.0f);

--- a/math/Vector3.h
+++ b/math/Vector3.h
@@ -22,7 +22,7 @@ class Vector3
 public:
     Vector3() { x = 0.0f; y = 0.0f; z = 0.0f; }
     Vector3(float _x, float _y, float _z) { x = _x; y = _y; z = _z; }
-    ~Vector3() {;}
+	~Vector3() = default;
 
     float Length()
     {
@@ -100,8 +100,8 @@ public:
     inline Vector3 operator/(float scale) { return Vector3(x/scale, y/scale, z/scale); }
     inline Vector3 operator-() { return Vector3(-x, -y, -z); }
 
-    inline bool operator==(Vector3& other) { return ( fabsf(x-other.x)<VEC_EPS && fabsf(y-other.y)<VEC_EPS && fabsf(z-other.z)<VEC_EPS )?(true):(false); }
-    inline bool operator!=(Vector3& other) { return ( fabsf(x-other.x)>VEC_EPS || fabsf(y-other.y)>VEC_EPS || fabsf(z-other.z)>VEC_EPS )?(true):(false); }
+    inline bool operator==(const Vector3& other) const { return ( fabsf(x-other.x)<VEC_EPS && fabsf(y-other.y)<VEC_EPS && fabsf(z-other.z)<VEC_EPS )?(true):(false); }
+    inline bool operator!=(const Vector3& other) const { return ( fabsf(x-other.x)>VEC_EPS || fabsf(y-other.y)>VEC_EPS || fabsf(z-other.z)>VEC_EPS )?(true):(false); }
 
     inline float Mag2() { return (x*x+y*y+z*z); }
     inline float Max() { return ( (x>y)?(x>z?x:z):(y>z?y:z) ); }
@@ -127,9 +127,12 @@ public:
 
     float x, y, z;
 
-    static Vector3 One;
-    static Vector3 Half;
-    static Vector3 Zero;
+    static const Vector3 One;
+    static const Vector3 Half;
+    static const Vector3 Zero;
+    static const Vector3 UnitX;
+    static const Vector3 UnitY;
+    static const Vector3 UnitZ;
 };
 
 #endif //VECTOR3_H

--- a/math/Vector3.h
+++ b/math/Vector3.h
@@ -22,7 +22,7 @@ class Vector3
 public:
     Vector3() { x = 0.0f; y = 0.0f; z = 0.0f; }
     Vector3(float _x, float _y, float _z) { x = _x; y = _y; z = _z; }
-	~Vector3() = default;
+    ~Vector3() = default;
 
     float Length()
     {

--- a/math/Vector4.cpp
+++ b/math/Vector4.cpp
@@ -1,9 +1,12 @@
 #include "Vector4.h"
-#include <cmath>
 
-Vector4 Vector4::One(1.0f, 1.0f, 1.0f, 1.0f);
-Vector4 Vector4::Half(0.5f, 0.5f, 0.5f, 0.5f);
-Vector4 Vector4::Zero(0.0f, 0.0f, 0.0f, 0.0f);
+const Vector4 Vector4::One(1.0f, 1.0f, 1.0f, 1.0f);
+const Vector4 Vector4::Half(0.5f, 0.5f, 0.5f, 0.5f);
+const Vector4 Vector4::Zero(0.0f, 0.0f, 0.0f, 0.0f);
+const Vector4 Vector4::UnitX(1.0f, 0.0f, 0.0f, 0.0f);
+const Vector4 Vector4::UnitY(0.0f, 1.0f, 0.0f, 0.0f);
+const Vector4 Vector4::UnitZ(0.0f, 0.0f, 1.0f, 0.0f);
+const Vector4 Vector4::UnitW(0.0f, 0.0f, 0.0f, 1.0f);
 
 float Vector4::Normalize()
 {

--- a/math/Vector4.h
+++ b/math/Vector4.h
@@ -10,7 +10,7 @@ class Vector4
 public:
     Vector4() { x = 0.0f; y = 0.0f; z = 0.0f; w = 0.0f; }
     Vector4(float _x, float _y, float _z, float _w) { x = _x; y = _y; z = _z; w = _w; }
-	~Vector4() = default;
+    ~Vector4() = default;
 
     float Normalize();
     float Normalize3();

--- a/math/Vector4.h
+++ b/math/Vector4.h
@@ -10,7 +10,7 @@ class Vector4
 public:
     Vector4() { x = 0.0f; y = 0.0f; z = 0.0f; w = 0.0f; }
     Vector4(float _x, float _y, float _z, float _w) { x = _x; y = _y; z = _z; w = _w; }
-    ~Vector4() {;}
+	~Vector4() = default;
 
     float Normalize();
     float Normalize3();
@@ -38,9 +38,13 @@ public:
     float x, y, z, w;
     Vector3 m_v3;
 
-    static Vector4 One;
-    static Vector4 Half;
-    static Vector4 Zero;
+    static const Vector4 One;
+    static const Vector4 Half;
+    static const Vector4 Zero;
+    static const Vector4 UnitX;
+    static const Vector4 UnitY;
+    static const Vector4 UnitZ;
+    static const Vector4 UnitW;
 };
 
 #endif //VECTOR4_H

--- a/render/Driver3D_OGL.cpp
+++ b/render/Driver3D_OGL.cpp
@@ -283,7 +283,7 @@ void Driver3D_OGL::SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY)
     }
 }
 
-void Driver3D_OGL::SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir)
+void Driver3D_OGL::SetViewMatrix(Matrix *pMtx, const Vector3 *pLoc, const Vector3 *pDir)
 {
     m_ViewMtx = *pMtx;
     m_Eye = *pLoc;
@@ -347,7 +347,7 @@ void Driver3D_OGL::SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, bWrap ? GL_REPEAT : GL_CLAMP);
 }
 
-void Driver3D_OGL::SetColor(Vector4 *pColor)
+void Driver3D_OGL::SetColor(const Vector4 *pColor)
 {
     if ( pColor == nullptr ) pColor = &Vector4::One;
 

--- a/render/Driver3D_OGL.h
+++ b/render/Driver3D_OGL.h
@@ -23,7 +23,7 @@ class Driver3D_OGL : public IDriver3D
         void Clear(bool bClearColor=true) override;
 
         void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
-        void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
+        void SetViewMatrix(Matrix *pMtx, const Vector3 *pLoc, const Vector3 *pDir) override;
         void SetProjMtx(Matrix *pMtx) override;
         void SetCamera(Camera *pCamera) override;
 
@@ -31,7 +31,7 @@ class Driver3D_OGL : public IDriver3D
 
         //Texture Functions.
         void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
-        void SetColor(Vector4 *pColor=0) override;
+        void SetColor(const Vector4 *pColor=nullptr) override;
         TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
         void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
         void FreeTexture(TextureHandle hTex) override;

--- a/render/Driver3D_Soft.cpp
+++ b/render/Driver3D_Soft.cpp
@@ -653,7 +653,7 @@ void Driver3D_Soft::SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY)
     }
 }
 
-void Driver3D_Soft::SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir)
+void Driver3D_Soft::SetViewMatrix(Matrix *pMtx, const Vector3 *pLoc, const Vector3 *pDir)
 {
     m_ViewMtx = *pMtx;
     m_Eye = *pLoc;
@@ -701,7 +701,7 @@ void Driver3D_Soft::SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilte
     assert( m_pCurTex && m_pCurTex->m_pData[ DrawScanline::_uCurFrame ] );
 }
 
-void Driver3D_Soft::SetColor(Vector4 *pColor)
+void Driver3D_Soft::SetColor(const Vector4 *pColor)
 {
 }
 

--- a/render/Driver3D_Soft.h
+++ b/render/Driver3D_Soft.h
@@ -49,7 +49,7 @@ class Driver3D_Soft : public IDriver3D
         void Clear(bool bClearColor=true) override;
 
         void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) override;
-        void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) override;
+        void SetViewMatrix(Matrix *pMtx, const Vector3 *pLoc, const Vector3 *pDir) override;
         void SetProjMtx(Matrix *pMtx) override;
         void SetCamera(Camera *pCamera) override;
         
@@ -57,7 +57,7 @@ class Driver3D_Soft : public IDriver3D
 
         //Texture Functions.
         void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) override;
-        void SetColor(Vector4 *pColor=0) override;
+        void SetColor(const Vector4 *pColor=nullptr) override;
         TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) override;
         void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) override;
         void FreeTexture(TextureHandle hTex) override;

--- a/render/FontManager.cpp
+++ b/render/FontManager.cpp
@@ -135,7 +135,7 @@ void FontManager::EndTextRendering()
     m_pDriver->SetColor( &Vector4::One );
 }
 
-void FontManager::RenderString(int32_t x, int32_t y, const std::string& szString, XLFont *pFont, Vector4 *pColor)
+void FontManager::RenderString(int32_t x, int32_t y, const std::string& szString, XLFont *pFont, const Vector4 *pColor)
 {
     TextureHandle hTex = pFont->GetTexture();
 

--- a/render/FontManager.h
+++ b/render/FontManager.h
@@ -28,7 +28,7 @@ public:
     static void BeginTextRendering();
     static void EndTextRendering();
     //Render a string at location(x,y) using font pFont
-    static void RenderString(int32_t x, int32_t y, const std::string& szString, XLFont *pFont, Vector4 *pColor=&Vector4::One);
+    static void RenderString(int32_t x, int32_t y, const std::string& szString, XLFont *pFont, const Vector4 *pColor=&Vector4::One);
     static uint32_t GetLength(const std::string& szString, uint32_t uPosInString, XLFont *pFont);
 
 private:

--- a/render/IDriver3D.h
+++ b/render/IDriver3D.h
@@ -99,7 +99,7 @@ class IDriver3D
         virtual void Clear(bool bClearColor=true) {};
 
         virtual void SetWorldMatrix(Matrix *pMtx, int32_t worldX, int32_t worldY) {};
-        virtual void SetViewMatrix(Matrix *pMtx, Vector3 *pLoc, Vector3 *pDir) {};
+        virtual void SetViewMatrix(Matrix *pMtx, const Vector3 *pLoc, const Vector3 *pDir) {};
         virtual void SetProjMtx(Matrix *pMtx) {};
         virtual void SetCamera(Camera *pCamera) {};
         virtual Camera *GetCamera() {return nullptr;}
@@ -109,7 +109,7 @@ class IDriver3D
         //Texture Functions.
         //SetTexture(...) : frame=-1 : use the automatic texture animation system (used for most things).
         virtual void SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter=FILTER_NORMAL, bool bWrap=true, int32_t frame=-1) {};
-        virtual void SetColor(Vector4 *pColor=0) {};
+        virtual void SetColor(const Vector4 *pColor=nullptr) {};
         virtual TextureHandle CreateTexture(uint32_t uWidth, uint32_t uHeight, uint32_t uFormat=TEX_FORMAT_RGBA8, uint8_t *pData=0, bool bGenMips=false, int32_t nFrameCnt=1) {return 0;}
         virtual void FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWidth, uint32_t uHeight, bool bGenMips=false) {};
         virtual void FreeTexture(TextureHandle hTex) {};

--- a/world/Sector_2_5D.cpp
+++ b/world/Sector_2_5D.cpp
@@ -450,7 +450,7 @@ void Sector_2_5D::RenderSectors(IDriver3D *pDriver, WorldCell *pCell, Camera *pC
     projMtx.ProjOrtho((float)1024, (float)768);
 
     pDriver->SetProjMtx( &projMtx );
-    pDriver->SetViewMatrix( &Matrix::s_Identity, &Vector3(0,0,0), &Vector3(0,0,1) );
+    pDriver->SetViewMatrix( &Matrix::s_Identity, &Vector3::Zero, &Vector3::UnitZ );
     pDriver->SetWorldMatrix( &Matrix::s_Identity, 0, 0 );
 
     pDriver->EnableDepthWrite(false);
@@ -1830,7 +1830,7 @@ void Sector_2_5D::Visibility2D(const Vector3& cPos, Vector2 fL, Vector2 fR, uint
         bool bVisible = true;
         if ( ClipAgainstFrustum(v0, v1, ws[0], ws[1], bVisible) )
         {
-            m_Camera2D.TransformPointsSS_2D(2, ws, ss, Vector2(0.0f, 0.0f));
+            m_Camera2D.TransformPointsSS_2D(2, ws, ss, Vector2::Zero);
         }
         else
         {


### PR DESCRIPTION
Added const-qualified unit X, Y, Z, etc. members to `Vector{2,3,4}` classes, and added `const` to places that reference those members so it compiles.

Interestingly, projects in the solution other than XLEngine will fail to link if they reference any of those members (none of them are, though). Maybe something worth looking into? I think it implies that the XLEngine project makes its .obj files after the other ones, but the other ones have to link to the vector .objs first? Anyway, not a problem right now because it compiles and links, but it is strange nonetheless.

If this PR fails to compile on Clang, then we'll have to move each const vector definition to their .h file (not sure why that happens; it seems to be unique to Clang. Maybe it only happens when templates are involved).