### PR TITLE
Replace iterator erase() loops with find_if()

### DIFF
--- a/world/LevelFuncMgr.cpp
+++ b/world/LevelFuncMgr.cpp
@@ -2,6 +2,8 @@
 #include "WorldCell.h"
 #include "LevelFunc_Default.h"
 
+#include <algorithm>
+
 std::vector<LevelFunc *> LevelFuncMgr::m_FuncList;
 std::vector<LevelFunc *> LevelFuncMgr::m_Active;
 std::vector<LevelFunc *> LevelFuncMgr::m_AddList;
@@ -72,16 +74,15 @@ void LevelFuncMgr::DestroyLevelFunc(LevelFunc *pFunc)
 
     RemoveFromActiveList(pFunc);
 
-    std::vector<LevelFunc *>::iterator iter = m_FuncList.begin();
-    std::vector<LevelFunc *>::iterator end  = m_FuncList.end();
-
-    for (; iter != end; ++iter)
+    const auto iter = std::find_if(m_FuncList.begin(), m_FuncList.end(),
+        [pFunc](const LevelFunc *levelFunc)
     {
-        if ( *iter == pFunc )
-        {
-            m_FuncList.erase( iter );
-            break;
-        }
+        return levelFunc == pFunc;
+    });
+
+    if (iter != m_FuncList.end())
+    {
+        m_FuncList.erase(iter);
     }
 
     delete pFunc;
@@ -117,20 +118,20 @@ void LevelFuncMgr::Update()
     //go through the remove list and remove classes...
     if ( m_RemoveList.size() )
     {
-        for (LevelFunc *remFunc : m_RemoveList)
+        for (const LevelFunc *remFunc : m_RemoveList)
         {
-            std::vector<LevelFunc *>::iterator iActive = m_Active.begin();
-            std::vector<LevelFunc *>::iterator eActive = m_Active.end();
-
-            for (; iActive!=eActive; ++iActive)
+            const auto iter = std::find_if(m_Active.begin(), m_Active.end(),
+                [remFunc](const LevelFunc *activeFunc)
             {
-                if ( *iActive == remFunc )
-                {
-                    m_Active.erase(iActive);
-                    break;
-                }
+                return activeFunc == remFunc;
+            });
+
+            if (iter != m_Active.end())
+            {
+                m_Active.erase(iter);
             }
         }
+
         m_RemoveList.clear();
     }
 }

--- a/world/ObjectManager.cpp
+++ b/world/ObjectManager.cpp
@@ -232,15 +232,15 @@ void ObjectManager::FreeObject(Object *pObj)
     m_FreeObjects.push_back( pObj );
 
     //remove this from the active object list.
-    std::vector<Object *>::iterator iObj = m_ActiveObjects.begin();
-    std::vector<Object *>::iterator eObj = m_ActiveObjects.end();
-    for (; iObj != eObj; ++iObj)
+    const auto iter = std::find_if(m_ActiveObjects.begin(), m_ActiveObjects.end(),
+        [pObj](const Object *activeObj)
     {
-        if ( (*iObj) == pObj )
-        {
-            m_ActiveObjects.erase( iObj );
-            break;
-        }
+        return activeObj == pObj;
+    });
+
+    if (iter != m_ActiveObjects.end())
+    {
+        m_ActiveObjects.erase(iter);
     }
 }
 

--- a/world/Sector.cpp
+++ b/world/Sector.cpp
@@ -1,5 +1,7 @@
 #include "Sector.h"
 
+#include <algorithm>
+
 uint32_t Sector::s_MaxSecDrawCnt=0;
 
 Sector::Sector()
@@ -32,14 +34,14 @@ void Sector::AddObject(uint32_t uHandle)
 void Sector::RemoveObject(uint32_t uHandle)
 {
     //search for object handle and then erase it.
-    std::vector<uint32_t>::iterator iObj = m_Objects.begin();
-    std::vector<uint32_t>::iterator eObj = m_Objects.end();
-    for ( ; iObj != eObj; ++iObj )
+    const auto iter = std::find_if(m_Objects.begin(), m_Objects.end(),
+        [uHandle](const uint32_t objID)
     {
-        if ( *iObj == uHandle )
-        {
-            m_Objects.erase( iObj );
-            break;
-        }
+        return objID == uHandle;
+    });
+
+    if (iter != m_Objects.end())
+    {
+        m_Objects.erase(iter);
     }
 }

--- a/world/World.cpp
+++ b/world/World.cpp
@@ -9,8 +9,9 @@
 #include "../fileformats/Location_Daggerfall.h"
 #include "../fileformats/CellManager.h"
 
-#include <string>
+#include <algorithm>
 #include <cstdio>
+#include <string>
 
 World::World()
 {
@@ -52,16 +53,16 @@ bool World::AddWorldCell(WorldCell *pCell)
 
 void World::RemoveWorldCell(WorldCell *pCell)
 {
-    std::vector<WorldCell *>::iterator iCell = m_WorldCells.begin();
-    std::vector<WorldCell *>::iterator eCell = m_WorldCells.end();
-    for (; iCell != eCell; ++iCell)
+    const auto iter = std::find_if(m_WorldCells.begin(), m_WorldCells.end(),
+        [pCell](const WorldCell *worldCell)
     {
-        if ( *iCell == pCell )
-        {
-            xlDelete pCell;
-            m_WorldCells.erase( iCell );
-            break;
-        }
+        return worldCell == pCell;
+    });
+
+    if (iter != m_WorldCells.end())
+    {
+        xlDelete pCell;
+        m_WorldCells.erase(iter);
     }
 }
 


### PR DESCRIPTION
I think it's more clear to use `std::find_if()` instead of a loop because the intent is to find the first element that satisfies the condition.

I used a reverse iterator in `render/TextureCache.cpp` because the loop doesn't break on the first found element, which means it finds the element closest to the end of the texture map. The conversion from reverse iterator to forward iterator is a little weird but I believe it's correct.