### PR TITLE
Replace trivial find_ifs with find

### DIFF
--- a/world/LevelFuncMgr.cpp
+++ b/world/LevelFuncMgr.cpp
@@ -74,11 +74,7 @@ void LevelFuncMgr::DestroyLevelFunc(LevelFunc *pFunc)
 
     RemoveFromActiveList(pFunc);
 
-    const auto iter = std::find_if(m_FuncList.begin(), m_FuncList.end(),
-        [pFunc](const LevelFunc *levelFunc)
-    {
-        return levelFunc == pFunc;
-    });
+    const auto iter = std::find(m_FuncList.begin(), m_FuncList.end(), pFunc);
 
     if (iter != m_FuncList.end())
     {

--- a/world/ObjectManager.cpp
+++ b/world/ObjectManager.cpp
@@ -232,11 +232,7 @@ void ObjectManager::FreeObject(Object *pObj)
     m_FreeObjects.push_back( pObj );
 
     //remove this from the active object list.
-    const auto iter = std::find_if(m_ActiveObjects.begin(), m_ActiveObjects.end(),
-        [pObj](const Object *activeObj)
-    {
-        return activeObj == pObj;
-    });
+    const auto iter = std::find(m_ActiveObjects.begin(), m_ActiveObjects.end(), pObj);
 
     if (iter != m_ActiveObjects.end())
     {

--- a/world/Sector.cpp
+++ b/world/Sector.cpp
@@ -34,11 +34,7 @@ void Sector::AddObject(uint32_t uHandle)
 void Sector::RemoveObject(uint32_t uHandle)
 {
     //search for object handle and then erase it.
-    const auto iter = std::find_if(m_Objects.begin(), m_Objects.end(),
-        [uHandle](const uint32_t objID)
-    {
-        return objID == uHandle;
-    });
+    const auto iter = std::find(m_Objects.begin(), m_Objects.end(), uHandle);
 
     if (iter != m_Objects.end())
     {

--- a/world/World.cpp
+++ b/world/World.cpp
@@ -53,11 +53,7 @@ bool World::AddWorldCell(WorldCell *pCell)
 
 void World::RemoveWorldCell(WorldCell *pCell)
 {
-    const auto iter = std::find_if(m_WorldCells.begin(), m_WorldCells.end(),
-        [pCell](const WorldCell *worldCell)
-    {
-        return worldCell == pCell;
-    });
+    const auto iter = std::find(m_WorldCells.begin(), m_WorldCells.end(), pCell);
 
     if (iter != m_WorldCells.end())
     {


### PR DESCRIPTION
Some of the `std::find_if()` calls added in PR #36 don't need a custom comparator function since they can simply compare values against the given argument instead.