### PR TITLE
Only load lower cased game directory resources

### DIFF
--- a/EngineSettings.cpp
+++ b/EngineSettings.cpp
@@ -243,12 +243,17 @@ void EngineSettings::SetGameName(const char *game)
     mGameDir += game;
 }
 
-const char *EngineSettings::GetGameDataDir()
+const std::string EngineSettings::GetGameDataDir()
 {
     auto iter = mGameDataDirs.find(mGameName);
     if(iter != mGameDataDirs.end())
-        return iter->second.c_str();
-    return "";
+        return iter->second;
+    return std::string("");
+}
+
+const std::string EngineSettings::GetGameResource(const char *name)
+{
+    return GetGameDataDir() + ToLower(name);
 }
 
 

--- a/EngineSettings.h
+++ b/EngineSettings.h
@@ -66,7 +66,7 @@ class EngineSettings
 
         void SetGameName(const char *game);
         const char *GetGameDir() { return mGameDir.c_str(); }
-        const char *GetGameDataDir();
+        const std::string GetGameResource(const char *name);
 
         int32_t GetRenderer() { return mRenderer; }
         void SetRenderer(int32_t renderer) { mRenderer = renderer; }
@@ -108,6 +108,8 @@ class EngineSettings
         float mGamma = 1.0f;
 
         uint32_t mFlags = 0;
+
+        const std::string GetGameDataDir();
 };
 
 #endif // ENGINESETTINGS_H

--- a/fileformats/ART_Reader.cpp
+++ b/fileformats/ART_Reader.cpp
@@ -19,8 +19,7 @@ ART_Reader::ART_Reader() : Archive()
 
 bool ART_Reader::Open(const char *name)
 {
-    mFileName = EngineSettings::get().GetGameDataDir();
-    mFileName += name;
+    mFileName = EngineSettings::get().GetGameResource(name);
 
     auto file = Vfs::get().openInput(mFileName);
     if(!file)

--- a/fileformats/ArchiveManager.cpp
+++ b/fileformats/ArchiveManager.cpp
@@ -190,7 +190,7 @@ int32_t ArchiveManager::File_Open(const char *fname)
         return 0;
 
     sCurrentSysFile = Vfs::get().openInput(
-        std::string(EngineSettings::get().GetGameDataDir()) + fname
+        EngineSettings::get().GetGameResource(fname)
     );
     if(sCurrentSysFile) return 1;
     return 0;

--- a/fileformats/BSA_Reader.cpp
+++ b/fileformats/BSA_Reader.cpp
@@ -14,8 +14,7 @@ BSA_Reader::BSA_Reader() : Archive()
 
 bool BSA_Reader::Open(const char *name)
 {
-    mFileName = EngineSettings::get().GetGameDataDir();
-    mFileName += name;
+    mFileName = EngineSettings::get().GetGameResource(name);
 
     auto file = Vfs::get().openInput(mFileName);
     if(!file)

--- a/fileformats/GOB_Reader.cpp
+++ b/fileformats/GOB_Reader.cpp
@@ -14,8 +14,7 @@ GOB_Reader::GOB_Reader() : Archive()
 
 bool GOB_Reader::Open(const char *name)
 {
-    mFileName = EngineSettings::get().GetGameDataDir();
-    mFileName += name;
+    mFileName = EngineSettings::get().GetGameResource(name);
 
     m_bGOB = true;
     size_t l = strlen(name);

--- a/fileformats/LFD_Reader.cpp
+++ b/fileformats/LFD_Reader.cpp
@@ -11,15 +11,15 @@ LFD_Reader::LFD_Reader() : Archive()
 
 bool LFD_Reader::Open(const char *name)
 {
-    mFileName = EngineSettings::get().GetGameDataDir();
-    mFileName += "LFD/";
-    mFileName += name;
+    char fname[32];
+    sprintf(fname, "lfd/%s", name);
+    mFileName = EngineSettings::get().GetGameResource(fname);
 
     auto file = Vfs::get().openInput(mFileName);
     if(!file)
     {
-        XL_Console::PrintF("^1Error: Failed to load %s, make sure that %sLFD is the correct directory for Dark Forces.",
-                           mFileName.c_str(), EngineSettings::get().GetGameDataDir());
+        XL_Console::PrintF("^1Error: Failed to load %s, make sure that LFD sub-directory exists for Dark Forces.",
+                           mFileName.c_str());
         return false;
     }
 

--- a/fileformats/RFF_Reader.cpp
+++ b/fileformats/RFF_Reader.cpp
@@ -59,8 +59,7 @@ RFF_Reader::RFF_Reader() : Archive()
 
 bool RFF_Reader::Open(const char *name)
 {
-    mFileName = EngineSettings::get().GetGameDataDir();
-    mFileName += name;
+    mFileName = EngineSettings::get().GetGameResource(name);
 
     auto file = Vfs::get().openInput(mFileName);
     if(!file)


### PR DESCRIPTION
The naming is not consistent, so for the sake of filesystems that are case aware convert all game directory filenames to lower case.