### PR TITLE
OpenGL display terrain and sky

### DIFF
--- a/Engine.cpp
+++ b/Engine.cpp
@@ -90,7 +90,7 @@ Engine::Engine()
     m_pSystemFont24 = nullptr;
     m_pSystemFont32 = nullptr;
     m_pWorld = nullptr;
-    m_FPS = 60.0f;
+    m_FPS = 144.0f; //default was 60.0f
 }
 
 Engine::~Engine()

--- a/render/Camera.cpp
+++ b/render/Camera.cpp
@@ -18,7 +18,7 @@ Camera::Camera()
     m_fFOV    = 65.0f * dtor;       //FOV in radians.
     m_fAspect = 1.0f;
     m_fNearZ  = 0.1f;
-    m_fFarZ   = 1000.0f;
+    m_fFarZ   = 10000.0f; // default was 1000
     m_fFrustumWidth = 1.0f;
     m_fSkew = 0.0f;
     m_fMaxRenderDist = 400.0f;
@@ -171,7 +171,7 @@ int Camera::SphereInsideFrustum(Vector3& vCen, float fRadius)
     }
 
 #if 0
-    if ( -vCen.z + fRadius < 0.0f ) 
+    if ( -vCen.z + fRadius < 0.0f )
     {
         return FRUSTUM_OUT;
     }

--- a/render/Driver3D_OGL.cpp
+++ b/render/Driver3D_OGL.cpp
@@ -68,6 +68,18 @@ TextureOGL *Driver3D_OGL::m_pCurTex;
 uint32_t Driver3D_OGL::s_uColormapID;
 static uint32_t *_pCurPal = nullptr;
 
+
+// Values that control the material properties.
+float Noemit[4] = {0.0, 0.0, 0.0, 1.0};
+
+// Lighting values
+float ambientLight[4] = {0, 0, 0, 1.0};
+float Lt0amb[4] = {0.3, 0.3, 0.3, 1.0};
+float Lt0diff[4] = {1.0, 1.0, 1.0, 1.0};
+float Lt0spec[4] = {1.0, 1.0, 1.0, 1.0};
+
+float zeroPos[4] = {0, 0, 0, 1};         // Origin (homogeneous representation)
+
 Driver3D_OGL::Driver3D_OGL() : IDriver3D(), m_pRenderCamera(0)
 {
     m_uTextureCnt = 0;
@@ -136,6 +148,39 @@ bool Driver3D_OGL::Init(int32_t w, int32_t h)
     glHint(GL_FOG_HINT, GL_NICEST);
     glFogf(GL_FOG_START, 1.0f);
     glFogf(GL_FOG_END, 150.0f);
+
+
+    // lighting
+
+   // // Position the light (before drawing the illuminated objects)
+   // glPushMatrix();
+   // glRotatef( CurrentAngle, 0.0, 35.0, 1.0 );      // Rotate through animation angle
+   // glTranslatef( 7.0, 0.0, 0.0 );               // Translate rotation center to origin
+   // glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, Lt0spec);   // Make sphere glow (emissive)
+   // // glutSolidSphere(0.3, 5, 5);
+   // glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, Noemit);   // Turn off emission
+   //
+   // if ( LightIsPositional==1 ) {
+   //    glLightfv(GL_LIGHT0, GL_POSITION, zeroPos );   // Position is transformed by ModelView matrix
+   // }
+   // else {
+   //    glLightfv(GL_LIGHT0, GL_POSITION, dirI );      // Direction is transformed by ModelView matrix
+   // }
+   // glPopMatrix();
+
+    glEnable(GL_LIGHTING);      // Enable lighting calculations
+    glEnable(GL_LIGHT0);      // Turn on light #0.
+
+    // Set global ambient light
+    glLightModelfv(GL_LIGHT_MODEL_AMBIENT, ambientLight);
+
+    // Light 0 light values.  Its position is set in drawScene().
+    glLightfv(GL_LIGHT0, GL_POSITION, zeroPos );   // Position is transformed by ModelView matrix
+    glLightf(GL_LIGHT0, GL_CONSTANT_ATTENUATION,.75);
+    // glLightfv(GL_LIGHT0, GL_AMBIENT, Lt0amb);
+    glLightfv(GL_LIGHT0, GL_DIFFUSE, Lt0diff);
+    glLightfv(GL_LIGHT0, GL_SPECULAR, Lt0spec);
+
 
     glActiveTexture(GL_TEXTURE0);
 
@@ -221,9 +266,9 @@ void Driver3D_OGL::EnableFog(bool bEnable, float fEnd)
     if ( _fFogEnd != fEnd ) { glFogf(GL_FOG_END, fEnd); _fFogEnd = fEnd; }
     if ( bEnable != _bFogEnable )
     {
-        if ( bEnable )
-            glEnable(GL_FOG);
-        else
+        // if ( bEnable )
+            // glEnable(GL_FOG);
+        // else
             glDisable(GL_FOG);
         _bFogEnable = bEnable;
     }

--- a/render/Driver3D_OGL.cpp
+++ b/render/Driver3D_OGL.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include <inttypes.h>
 #include "../ui/XL_Console.h"
 #include "../fileformats/TextureLoader.h"
 
@@ -25,8 +26,9 @@
 #endif
 
 
-
 #define BUFFER_OFFSET(i) ((char *)nullptr + (i))
+
+#define MAX_PAL_COUNT 32
 
 uint32_t _uPrevVBO = 0xffffffff;
 uint32_t _uBlendFunc = 0;
@@ -57,8 +59,8 @@ uint32_t _uAlphaCutoff = 0;
 uint32_t _uStencilValue = 0xff;
 
 bool _bFogEnable = false;
-float _fFogDensity = 1.0f;
-float _fFogEnd = 0.0f;
+float _fFogDensity = 0.25f;
+float _fFogEnd = 150.0f;
 
 Matrix *_prevWorldMtxPtr = nullptr;
 
@@ -73,10 +75,16 @@ static uint32_t *_pCurPal = nullptr;
 float Noemit[4] = {0.0, 0.0, 0.0, 1.0};
 
 // Lighting values
-float ambientLight[4] = {0, 0, 0, 1.0};
-float Lt0amb[4] = {0.3, 0.3, 0.3, 1.0};
+// float ambientLight[4] = {0.5773502692, 0.5773502692, 0.5773502692, 1.0};
+
+float ambientLight[4] = {0.7773502692, 0.7773502692, 0.7773502692, 1.0};
+
+
+float Lt0amb[4] = {0.147, 0.12, 0.21, 1};
 float Lt0diff[4] = {1.0, 1.0, 1.0, 1.0};
 float Lt0spec[4] = {1.0, 1.0, 1.0, 1.0};
+
+GLfloat fogColor[4] = {0.0147, 0.012, 0.021, 1}; //set the for color to grey
 
 float zeroPos[4] = {0, 0, 0, 1};         // Origin (homogeneous representation)
 
@@ -85,6 +93,7 @@ Driver3D_OGL::Driver3D_OGL() : IDriver3D(), m_pRenderCamera(0)
     m_uTextureCnt = 0;
     m_pTexArray = nullptr;
     m_pTexIndex = nullptr;
+    m_bGouraud  = false;
     // m_Textures.clear();
 }
 
@@ -127,7 +136,7 @@ bool Driver3D_OGL::Init(int32_t w, int32_t h)
     glClearStencil(0);       /* Clear The Stencil Buffer To 0 */
 
     /* frame buffer clears should be to black */
-    glClearColor(0.0, 0.0, 0.0, 0.0);
+    // glClearColor(0.0, 0.0, 0.0, 0.0);
 
     /* set up projection transform */
     glMatrixMode(GL_PROJECTION);
@@ -143,11 +152,11 @@ bool Driver3D_OGL::Init(int32_t w, int32_t h)
     s_uColormapID = m_uColormapID;
     //default fog settings
     glFogi(GL_FOG_MODE, GL_LINEAR);
-    glFogfv(GL_FOG_COLOR, &Vector4::Zero.x);
-    glFogf(GL_FOG_DENSITY, 1.0f);
+    glFogfv(GL_FOG_COLOR, fogColor);
+    glFogf(GL_FOG_DENSITY, 0.3);
     glHint(GL_FOG_HINT, GL_NICEST);
-    glFogf(GL_FOG_START, 1.0f);
-    glFogf(GL_FOG_END, 150.0f);
+    glFogf(GL_FOG_START, 400);
+    glFogf(GL_FOG_END, 800000);
 
 
     // lighting
@@ -168,8 +177,9 @@ bool Driver3D_OGL::Init(int32_t w, int32_t h)
    // }
    // glPopMatrix();
 
-    glEnable(GL_LIGHTING);      // Enable lighting calculations
-    glEnable(GL_LIGHT0);      // Turn on light #0.
+    // glEnable(GL_LIGHTING);      // Enable lighting calculations
+    // glEnable(GL_LIGHT0);      // Turn on light #0.
+    glShadeModel (GL_SMOOTH); //set the shader to smooth shader
 
     // Set global ambient light
     glLightModelfv(GL_LIGHT_MODEL_AMBIENT, ambientLight);
@@ -251,6 +261,11 @@ void Driver3D_OGL::SetBlendMode(uint32_t uMode)
                 if ( _uBlendFunc == 0 ) glEnable( GL_BLEND );
                 glBlendFunc(GL_ONE, GL_ONE);
             break;
+            case BLEND_SKY:
+                if ( _uBlendFunc == 0 ) glEnable( GL_BLEND );
+                glBlendColor(1,0,1,1);
+                glBlendFuncSeparate(GL_ONE_MINUS_CONSTANT_COLOR, GL_ONE ,GL_ONE_MINUS_CONSTANT_COLOR, GL_ZERO);
+            break;
         };
         _uBlendFunc = uMode;
     }
@@ -258,17 +273,17 @@ void Driver3D_OGL::SetBlendMode(uint32_t uMode)
 
 void Driver3D_OGL::SetFogDensity(float fDensity)
 {
-    if ( _fFogDensity != fDensity ) { glFogf(GL_FOG_DENSITY, fDensity); _fFogDensity = fDensity; }
+    // if ( _fFogDensity != fDensity ) { glFogf(GL_FOG_DENSITY, fDensity); _fFogDensity = fDensity; }
 }
 
 void Driver3D_OGL::EnableFog(bool bEnable, float fEnd)
 {
-    if ( _fFogEnd != fEnd ) { glFogf(GL_FOG_END, fEnd); _fFogEnd = fEnd; }
+    // if ( _fFogEnd != fEnd ) { glFogf(GL_FOG_END, fEnd); _fFogEnd = fEnd; }
     if ( bEnable != _bFogEnable )
     {
-        // if ( bEnable )
-            // glEnable(GL_FOG);
-        // else
+        if ( bEnable )
+            glEnable(GL_FOG);
+        else
             glDisable(GL_FOG);
         _bFogEnable = bEnable;
     }
@@ -318,8 +333,41 @@ void Driver3D_OGL::EnableStencilTesting(bool bEnable)
 
 void Driver3D_OGL::Present()
 {
+    static uint32_t _palIdx = 0xffffffff;
+    if ( _pCurPal == nullptr || _palIdx != m_uPaletteID || m_bUpdatePal )
+    {
+        uint8_t *pal = TextureLoader::GetPaletteData(m_uPaletteID);
+        int index = 0;
+        for (uint32_t p=0; p<256; p++)
+        {
+            uint8_t r = pal[ index+0 ];
+            uint8_t g = pal[ index+1 ];
+            uint8_t b = pal[ index+2 ];
+            uint8_t a = pal[ index+3 ];
+
+            // _pCurPal[p] = (a<<24) | (r<<16) | (g<<8) | b;
+
+            index += 4;
+            // printf("%" PRIu32 "\n", _pCurPal[p] );
+        }
+        // _palIdx = m_uPaletteID;
+
+        // printf("%" PRIu32 "\n", _palIdx);
+        //BuildTransTable();
+        //if ( m_nBitDepth == 32 )
+        // {
+            //BuildColorTables_32bpp();
+        // }
+        // DrawScanline::_pCurPal = _pCurPal;
+
+        // m_bUpdatePal = false;
+    }
+
+    RenderOverlays();
+
     ClearDrawData();
     m_Platform->Present();
+
 }
 
 void Driver3D_OGL::Clear(bool bClearColor)
@@ -423,6 +471,10 @@ void Driver3D_OGL::BuildColorTables_32bpp(int refPalIndex/*=112*/)
 
 void Driver3D_OGL::SetClearColorFromTex(TextureHandle hTex)
 {
+
+    // glClearColor(0.5, 0.7, 0.8, 1.0);
+    glClearColor(0.203921, 0.560784, 0.9215686, 1.0);
+    // glClearColor(0.41176470588, 0.54509803921, 0.70196078431, 1.0);
     // m_pCurTex = m_Textures[hTex];
     // m_uClearColor = ((uint8_t *)m_pCurTex->m_pData[0])[ (m_pCurTex->m_nHeight-1)*m_pCurTex->m_nWidth ];
 }
@@ -467,7 +519,6 @@ void Driver3D_OGL::SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     }
-
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, bWrap ? GL_REPEAT : GL_CLAMP);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, bWrap ? GL_REPEAT : GL_CLAMP);
 }
@@ -509,6 +560,11 @@ TextureHandle Driver3D_OGL::CreateTexture(uint32_t uWidth, uint32_t uHeight, uin
         type = GL_FLOAT;
         glFormat = GL_RED;
     }
+    else if ( uFormat == TEX_FORMAT_OTHER)
+    {
+        internalFormat = GL_RGBA8;
+        type = GL_UNSIGNED_BYTE;
+    }
     uint32_t uTextureID = m_uTextureCnt;
     m_uTextureCnt++;
 
@@ -520,15 +576,26 @@ TextureHandle Driver3D_OGL::CreateTexture(uint32_t uWidth, uint32_t uHeight, uin
         glTexImage2D(GL_TEXTURE_2D, 0, 4, uWidth, uHeight, 0, glFormat, type, pData);
     }
 
-    // if ( pData && bGenMips && uFormat == TEX_FORMAT_RGBA8 )
-    // {
+    if ( pData && bGenMips && uFormat == TEX_FORMAT_RGBA8 )
+    {
         GenerateMips(uWidth, uHeight, pData);
-    // }
-    // else
-    // {
-        // glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        // glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    // }
+    }
+    else
+    {
+
+      for (uint8_t i=0; i<sizeof(pData); i++)
+      {
+        GenerateMips(uWidth, uHeight, pData);
+          // glTexImage2D(GL_TEXTURE_2D, 0, 4, uWidth, uHeight, 0, GL_RGBA8, GL_UNSIGNED_BYTE, &pData[i]);
+        // glDisable(GL_COLOR_MATERIAL);
+        // glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+        // glTexImage2D(GL_TEXTURE_2D, 0, 4, uWidth, uHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, pData);
+        // GenerateMips(uWidth, uHeight, pData);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      }
+
+    }
 
     return m_Textures[uTextureID];
 }
@@ -577,8 +644,8 @@ void Driver3D_OGL::FillTexture(TextureHandle hTex, uint8_t *pData, uint32_t uWid
 
 void Driver3D_OGL::SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1)
 {
-    // if ( uExtension == EXT_TEXTURE_INDEX )
-    // {
+    if ( uExtension == EXT_TEXTURE_INDEX )
+    {
         m_pTexArray = (TextureHandle *)pData0;
         m_pTexIndex = (uint16_t *)pData1;
 
@@ -586,7 +653,16 @@ void Driver3D_OGL::SetExtension_Data(uint32_t uExtension, void *pData0, void *pD
         // XL_Console::PrintF("^1Error: pData1 to load %s", pData1);
         // SetTexture(0, m_pTexArray[m_pTexIndex]);
         // void Driver3D_OGL::SetTexture(int32_t slot, TextureHandle hTex, uint32_t uFilter, bool bWrap, int32_t frame);
-    // }
+
+
+
+    }
+
+    else if ( uExtension == EXT_GOURAUD )
+    {
+        int32_t enable = *((int32_t *)pData0);
+        m_bGouraud = enable ? true : false;
+    }
 }
 
 void Driver3D_OGL::GenerateMips(uint32_t uWidth, uint32_t uHeight, uint8_t *pData)
@@ -810,6 +886,69 @@ void Driver3D_OGL::ClearDrawData()
     _uPrevVBO = 0xffffffff;
 }
 
+
+
+void Driver3D_OGL::RenderOverlays()
+{
+    // for (uint32_t i=0; i<m_uOverlayCount; i++)
+    // {
+    //     int32_t tw = m_Textures[ m_Overlays[i].hTex ]->m_nWidth;
+    //     int32_t th = m_Textures[ m_Overlays[i].hTex ]->m_nHeight;
+    //
+    //     int32_t tx = m_Overlays[i].x;
+    //     int32_t ty = m_Overlays[i].y;
+    //     if ( tx >= (int32_t)m_FrameWidth || ty >= (int32_t)m_FrameHeight )
+    //         continue;
+    //
+    //     int32_t tw_Clipped = Math::Min( tx+tw*m_Overlays[i].scale, (int32_t)m_FrameWidth )-tx;
+    //     int32_t th_Clipped = Math::Min( ty+th*m_Overlays[i].scale, (int32_t)m_FrameHeight )-ty;
+    //     if ( tw_Clipped <= 0 || th_Clipped <= 0 )
+    //         continue;
+    //
+    //     uint32_t *pImage = (uint32_t *)m_Textures[ m_Overlays[i].hTex ]->m_pData[0];
+    //     int32_t xOffset = 0;
+    //     if ( tx < 0 )
+    //          xOffset = -tx;
+    //     int32_t yOffset = 0;
+    //     if ( ty < 0 )
+    //         yOffset = -ty;
+    //
+    //     int32_t texel_xOffset = xOffset/m_Overlays[i].scale;
+    //     int32_t texel_yOffset = yOffset/m_Overlays[i].scale;
+    //     int32_t tex_y = texel_yOffset;
+    //     int32_t stepsPerTexel = m_Overlays[i].scale;
+    //     int32_t stepsY = stepsPerTexel;
+    //     for (int32_t y=0; y<th_Clipped-yOffset; y++)
+    //     {
+    //         uint32_t *pImageV = &pImage[ tex_y*tw + texel_xOffset ];
+    //         int32_t fy = m_FrameHeight-(ty+y+yOffset)-1;
+    //
+    //         // uint32_t *pLine = &m_pFrameBuffer_32bpp[ fy*m_FrameWidth + tx + xOffset ];
+    //         int32_t tex_x = 0;
+    //         int32_t stepsX = stepsPerTexel;
+    //         for (int32_t x=0; x<tw_Clipped-xOffset; x++)
+    //         {
+    //             // *pLine++ = pImageV[tex_x];
+    //
+    //             stepsX--;
+    //             if ( stepsX == 0 )
+    //             {
+    //                  tex_x++;
+    //                  stepsX = stepsPerTexel;
+    //             }
+    //         }
+    //
+    //         stepsY--;
+    //         if ( stepsY == 0 )
+    //         {
+    //              tex_y++;
+    //              stepsY = stepsPerTexel;
+    //         }
+    //     }
+    // }
+    m_uOverlayCount = 0;
+}
+
 //The function assumes a vertex buffer has already been set.
 void Driver3D_OGL::RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int32_t startIndex/*=0*/)
 {
@@ -821,39 +960,30 @@ void Driver3D_OGL::RenderIndexedTriangles(IndexBuffer *pIB, int32_t nTriCnt, int
     //The is the number of indices. 3 indices needed to make a single triangle
     int idxCnt = nTriCnt*3;
 
-    // PolygonData *polyData = nullptr;//(PolygonData *)pIbo->pRendererData;
-    for (int t=0, i=startIndex; t<nTriCnt; t++, i+=3)
-    {
-        //EXT_TEXTURE_INDEX
-        if ( m_pTexArray )
-        {
-            // int32_t texIndex = m_pTexArray[m_pTexIndex[t>>1]&0xff];
-            // assert( (m_pTexIndex[t>>1]&0xff) < (56*4) );
-            // DrawScanline::_pCurTex = m_Textures[ texIndex ];
-            // DrawScanline::_texFlip = m_pTexIndex[t>>1]>>8;\
-
-
-            // SetTexture(0, m_pTexArray[m_pTexIndex[t]]);
-
-
-
-            // int32_t texIndex = m_pTexArray[m_pTexIndex[t>>1]&0xff];
-            // assert( (m_pTexIndex[t>>1]&0xff) < (56*4) );
-            // SetTexture(0,m_pTexArray[m_pTexIndex[t]]);
-            // DrawScanline::_pCurTex = m_Textures[ texIndex ];
-            // DrawScanline::_texFlip = m_pTexIndex[t>>1]>>8;
-            // SetTexture( m_Textures[ texIndex ],m_pTexIndex[t>>1]>>8);
-                // m_pTexArray = (TextureHandle *)pData0;
-                // m_pTexIndex = (uint16_t *)pData1;
-            // CreateTexture(1000, 500, IDriver3D::TEX_FORMAT_FORCE_32bpp, m_Textures[texIndex] , false);
-            // SetTexture(0,m_Textures[texIndex]);
-
-            // XL_Console::PrintF("^1Error: wtf to load %s",i);
-
-        }
-
-        // TriangleRasterizer::DrawClippedNGon_Indexed(this, m_pCurVBO, 3, &pIndices[i], s_uColormapID == 0 ? true : false, alphaMode, nullptr);//polyData?&polyData[t]:nullptr);
-    }
+    // for (int t=0, i=startIndex; t<nTriCnt*3; t++, i+=3)
+    // {
+    //     //EXT_TEXTURE_INDEX
+    //     if ( m_pTexArray )
+    //     {
+    //         // int32_t texIndex = m_pTexArray[m_pTexIndex[t>>1]&0xff];
+    //         // assert( (m_pTexIndex[t>>1]&0xff) < (56*4) );
+    //
+    //         // DrawScanline::_pCurTex = m_Textures[ texIndex ];
+    //         // DrawScanline::_texFlip = m_pTexIndex[t>>1]>>8;
+    //         // _curTex = texIndex
+    //         // SetTexture(0,m_pTexArray[0]);
+    //
+    //         // int32_t texIndex = m_pTexArray[m_pTexIndex[t]];
+    //         // SetTexture(0,texIndex);
+    //         // CreateTexture(64, 64, IDriver3D::TEX_FORMAT_RGBA8, m_Textures[texIndex], true, 1);
+    //
+    //
+    //         if(Input::IsKeyDown(XL_I)){
+    //
+    //           // printf("%s", m_Textures[0]);
+    //       }
+    //     }
+    // }
 
     glDrawRangeElements(GL_TRIANGLES, 0, idxCnt, idxCnt, (uStride==2)?GL_UNSIGNED_SHORT:GL_UNSIGNED_INT, BUFFER_OFFSET(startIndex*uStride));
 }

--- a/render/Driver3D_OGL.h
+++ b/render/Driver3D_OGL.h
@@ -7,6 +7,7 @@
 #include "../math/Vector2.h"
 #include "../math/Vector4.h"
 #include <cassert>
+#include <vector>
 
 
 struct TextureOGL
@@ -61,6 +62,8 @@ class Driver3D_OGL : public IDriver3D
         void SetVBO(uint32_t uID, uint32_t uStride, uint32_t uVBO_Flags) override;
         uint32_t CreateIB() override;
         void FillIB(uint32_t uID, void *pData, uint32_t uSize, bool bDynamic) override;
+        //Driver extensions
+        void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1) override;
         void DeleteBuffer(uint32_t uID) override;
         void ClearDrawData() override;
 
@@ -87,9 +90,9 @@ class Driver3D_OGL : public IDriver3D
         bool ApplyTransSort() override { return true; }
 
         Camera *GetCamera() override { return m_pRenderCamera; }
-        //Driver extensions
-        void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1) override;
+
         void SetClearColorFromTex(TextureHandle hTex) override;
+        bool GetGouraud()  { return m_bGouraud; }
         static uint8_t GetColormapID() { return s_uColormapID; }
         static TextureOGL *GetCurTex() { return m_pCurTex; }
 
@@ -99,6 +102,7 @@ class Driver3D_OGL : public IDriver3D
 
     private:
         uint32_t m_Textures[16384];
+        std::vector<TextureOGL *> m_TexturesOGL;
         uint32_t m_uTextureCnt;
         TextureHandle *m_pTexArray;
         uint16_t *m_pTexIndex;
@@ -109,6 +113,8 @@ class Driver3D_OGL : public IDriver3D
         static TextureOGL *m_pCurTex;
         static uint32_t s_uColormapID;
         PolygonDataOGL *m_pCurPolygonData;
+        void RenderOverlays();
+        bool m_bGouraud;
 };
 
 #endif // DRIVER3D_OGL_H

--- a/render/Driver3D_OGL.h
+++ b/render/Driver3D_OGL.h
@@ -8,6 +8,24 @@
 #include "../math/Vector4.h"
 #include <cassert>
 
+
+struct TextureOGL
+{
+    int32_t m_nWidth;
+    int32_t m_nHeight;
+    int32_t m_nMipCnt;
+    bool m_bIsPow2;
+    int32_t m_nFrameCnt;
+
+    uint32_t *m_pData[32];
+};
+
+struct PolygonDataOGL
+{
+    Vector3 nrmlWS;
+    Vector3 cenWS;
+    float   radius2_WS;
+};
 class IndexBuffer;
 
 class Driver3D_OGL : public IDriver3D
@@ -69,6 +87,11 @@ class Driver3D_OGL : public IDriver3D
         bool ApplyTransSort() override { return true; }
 
         Camera *GetCamera() override { return m_pRenderCamera; }
+        //Driver extensions
+        void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1) override;
+        void SetClearColorFromTex(TextureHandle hTex) override;
+        static uint8_t GetColormapID() { return s_uColormapID; }
+        static TextureOGL *GetCurTex() { return m_pCurTex; }
 
     protected:
 
@@ -77,8 +100,15 @@ class Driver3D_OGL : public IDriver3D
     private:
         uint32_t m_Textures[16384];
         uint32_t m_uTextureCnt;
+        TextureHandle *m_pTexArray;
+        uint16_t *m_pTexIndex;
 
         Camera *m_pRenderCamera;
+        void BuildColorTables_32bpp(int refPalIndex=112);
+        // TextureOGL *CreateCheckPattern();
+        static TextureOGL *m_pCurTex;
+        static uint32_t s_uColormapID;
+        PolygonDataOGL *m_pCurPolygonData;
 };
 
 #endif // DRIVER3D_OGL_H

--- a/render/IDriver3D.h
+++ b/render/IDriver3D.h
@@ -14,9 +14,9 @@ class IndexBuffer;
 class LightObject
 {
 public:
-    LightObject(Vector3 vLoc) 
-    { 
-        m_vLoc = vLoc; 
+    LightObject(Vector3 vLoc)
+    {
+        m_vLoc = vLoc;
         m_fLightAnim0 = s_fAnimOffset0; s_fAnimOffset0 +=  8.0f*0.13f;
         m_fLightAnim1 = s_fAnimOffset1; s_fAnimOffset1 += 32.0f*0.13f;
         m_fIntensity = 0.2f * (sinf(m_fLightAnim0)*0.5f+0.5f) + 0.1f * (sinf(m_fLightAnim1)*0.5f+0.5f) + 0.7f;
@@ -49,7 +49,8 @@ class IDriver3D
             TEX_FORMAT_RGBA32F,
             TEX_FORMAT_R32F,
             TEX_FORMAT_FORCE_32bpp,
-            TEX_FORMAT_COUNT
+            TEX_FORMAT_COUNT,
+            TEX_FORMAT_OTHER
         };
 
         enum VBO_Flags_e
@@ -66,6 +67,7 @@ class IDriver3D
             BLEND_NONE = 0,
             BLEND_ALPHA,
             BLEND_ADDITIVE,
+            BLEND_SKY,
             BLEND_COUNT
         };
 
@@ -160,8 +162,8 @@ class IDriver3D
         const Matrix& GetRenderCam_ViewMtx() { return m_ViewMtx; }
 
         void GetWindowSize(int32_t& nWidth, int32_t& nHeight)
-        { 
-            nWidth = m_nWindowWidth; nHeight = m_nWindowHeight; 
+        {
+            nWidth = m_nWindowWidth; nHeight = m_nWindowHeight;
         }
 
         //Lights.
@@ -184,7 +186,7 @@ class IDriver3D
         void ForceMipmapping(bool bForce) { m_bForceMip = bForce; }
         bool GetForceMipmapping() { return m_bForceMip; }
         virtual void SetExtension_Data(uint32_t uExtension, void *pData0, void *pData1) {};
-            
+
     protected:
         struct Overlay
         {

--- a/world/Terrain.cpp
+++ b/world/Terrain.cpp
@@ -114,15 +114,15 @@ int32_t Terrain::s_anMapFlat[]=
 
 void TerrainDebug_KeyDownCB(int32_t key)
 {
-    if ( key == XL_F3 )
+    if ( key == XL_P )
     {
         m_bShowTerrainDebug = !m_bShowTerrainDebug;
     }
-    if ( key == XL_ADD )
+    if ( key == XL_I )
     {
         m_nTerrainMapScale = Math::Min( m_nTerrainMapScale<<1, 16 );
     }
-    else if ( key == XL_SUBTRACT )
+    else if ( key == XL_O )
     {
         m_nTerrainMapScale = Math::Max( m_nTerrainMapScale>>1, 1 );
     }
@@ -842,6 +842,8 @@ bool Terrain::Update(int32_t x, int32_t y, int32_t nRectCnt, LocationRect *pRect
     return bUpdateNeeded;
 }
 
+
+
 void Terrain::RenderSky(int32_t skyIndex, int32_t timeIndex, Camera *pCamera)
 {
     m_pSkyLoader->LoadSky(skyIndex);
@@ -856,6 +858,8 @@ void Terrain::RenderSky(int32_t skyIndex, int32_t timeIndex, Camera *pCamera)
     TextureLoader::SetColormap(4, pSkyData->aColormaps[timeIndex].data, pSkyData->aColormaps[timeIndex].lightLevels);
 
     m_pDriver->SetClearColorFromTex(pSkyData->ahTexEast[timeIndex]);
+    // m_pDriver->SetSkyColors(8, pSkyData->aPalettes[timeIndex].colors, 768, 0);
+    // printf("%s", pSkyData->aColormaps[timeIndex].data);
     m_pDriver->SetCurrentPalette(8, true);
     m_pDriver->SetCurrentColormap(4);
     m_pDriver->SetAmbient(1.0f);
@@ -909,7 +913,12 @@ void Terrain::RenderSky(int32_t skyIndex, int32_t timeIndex, Camera *pCamera)
         posList[3].Set( vLoc.x+x0*cylTaper, vLoc.y+y0*cylTaper, zTop );
 
         TextureHandle hTex = ahTex[s/uDiv];
+
+        // m_pDriver->SetBlendMode( IDriver3D::BLEND_ALPHA );
+        m_pDriver->SetBlendMode( IDriver3D::BLEND_SKY);
         m_pDriver->SetTexture(0, hTex);
+        // m_pDriver->EnableAlphaTest(false);
+
         A += dA;
 
         x0 = x1;
@@ -919,6 +928,7 @@ void Terrain::RenderSky(int32_t skyIndex, int32_t timeIndex, Camera *pCamera)
     }
 
     m_pDriver->SetTexture(0, 0);
+    m_pDriver->SetBlendMode( IDriver3D::BLEND_NONE );
     pCamera->Compute(1.0f, true);
     pCamera->Set(m_pDriver);
     m_pDriver->SetAmbient(0.75f*195.0f/255.0f);
@@ -1118,36 +1128,30 @@ void Terrain::RenderLOD(Camera *pCamera, int32_t lod)
         {
             for (int i=0; i<(int)m_ChunkRenderList.size(); i++)
             {
-                // m_pDriver->SetExtension_Data(IDriver3D::EXT_TEXTURE_INDEX, m_ahTex, m_ChunkRenderList[i]->m_TileTexArray);
-
-                // m_pDriver->CreateTexture(64, 64, IDriver3D::TEX_FORMAT_RGBA8, (uint8_t *)&m_ChunkRenderList[i]->m_TileTexArray, true);
-                // m_pTexArray[m_pTexIndex[t>>1]&0xff]
-
-
                 m_pTexArray = (TextureHandle *)m_ahTex;
                 m_pTexIndex = (uint16_t *)m_ChunkRenderList[i]->m_TileTexArray;
-                //
-                // m_pDriver->SetTexture(0,m_pTexIndex[m_ahTex[i]]);
 
-
-                for (int t=0, i=0; t<TILE_QUAD_COUNT*2; t++, i+=3)
+                for (int t=0, i=0; t<(TILE_QUAD_COUNT*2); t++, i+=3)
                 {
                     //EXT_TEXTURE_INDEX
                     if ( m_pTexArray )
                     {
+
                         int32_t texIndex = m_pTexArray[m_pTexIndex[t>>1]&0xff];
                         assert( (m_pTexIndex[t>>1]&0xff) < (56*4) );
+
+                        // int32_t texIndex = m_pTexArray[m_pTexIndexi>>1]&0xff];
+
+                        // if(Input::IsKeyDown(XL_P)){
+                        //   printf("%d \n", texIndex);
+                        // }
+
                         m_pDriver->SetTexture(0, texIndex);
-
-                        // glBindTexture(GL_TEXTURE_2D, texIndex);
-                        // XL_Console::PrintF("^1Error: m_pTexIndexasdg", m_pTexIndex[t>>1]>>8);
-
                     }
-
                 }
-                // m_pDriver->CreateTexture(256,256, IDriver3D::TEX_FORMAT_RGBA8, (uint8_t *)&texIndex, false,0);
 
-                m_pDriver->RenderIndexedTriangles( m_ChunkRenderList[i]->m_pChunkIB, TILE_QUAD_COUNT*2);
+                m_pDriver->SetExtension_Data(IDriver3D::EXT_TEXTURE_INDEX, m_ahTex, m_ChunkRenderList[i]->m_TileTexArray);
+                m_pDriver->RenderIndexedTriangles(m_ChunkRenderList[i]->m_pChunkIB, TILE_QUAD_COUNT*2);
             }
         }
     }

--- a/world/Terrain.h
+++ b/world/Terrain.h
@@ -98,7 +98,7 @@ private:
     int32_t GetSkyIndex(int x, int y);
 
     void RenderSky(int32_t skyIndex, int32_t timeIndex, Camera *pCamera);
-    
+
     void LoadHeightmap();
     void BinLocations();
     void FilterHeightMap(uint8_t *pAltMap, float *pAltMapF, float *pCoastalDist);
@@ -170,7 +170,7 @@ private:
         }
         return pLoc;
     }
-    
+
     static bool SortCB_Chunks(Chunk*& d1, Chunk*& d2);
 
     static Vector3 m_vCamDir, m_vCamLoc;
@@ -180,6 +180,10 @@ private:
     static const Vector3 c_startPos;
     static int32_t s_anMapClimate[];
     static int32_t s_anMapFlat[];
+
+
+    TextureHandle *m_pTexArray;
+    uint16_t *m_pTexIndex;
 };
 
 #endif //TERRAIN_H


### PR DESCRIPTION
## Do not merge, for your debug eyes only.

The code is in playground mode and cleaning is required.

![image](https://user-images.githubusercontent.com/8145020/77822270-39dbec00-70bf-11ea-9128-c47d86cc098a.png)

### Terrain
Terrain is being displayed, however each chunk has the same texture, it's not properly assigning the right texture to each polygon.

Texture flip doesn't work yet either, these were all manually done through the 8b/32b scanline.

### Sky
Sky is all wrong, but it's prettier than white or pink. Basically I'm taking the pink color from the sky texture and making it blend with the clearbuffer. What really should be happening is that it should take the palette and color values and dynamically assign them to the textures...
The 8b/32b code is manually injecting the values during scanline process.


Hopefully this can help anyone fiddling around with this project.